### PR TITLE
Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# Top-most EditorConfig file
+root = true
+
+# Set the default charset
+[*]
+charset = utf-8
+
+# Makefile-specific settings
+[Makefile]
+indent_style = tab
+indent_size = 4
+
+# Ensure trailing whitespace is removed
+trim_trailing_whitespace = true
+
+# Set the end-of-line character as Unix-style (LF)
+end_of_line = lf
+
+# Ensure a new line at the end of the file
+insert_final_newline = true

--- a/Makefile
+++ b/Makefile
@@ -48,34 +48,34 @@ xcframework:
 	@echo "--- :xcode: Creating iOS Framework"
 
 	xcodebuild archive \
-	-workspace libraries/ios/WooCommerceShared.xcworkspace \
-	-scheme "WooCommerceShared" \
-	-configuration Release \
-    -destination "generic/platform=iOS" \
-	-archivePath dist/ios-platform \
-	-verbose \
-	| tee logs/ios-platform-build.log \
-	| xcbeautify
+		-workspace libraries/ios/WooCommerceShared.xcworkspace \
+		-scheme "WooCommerceShared" \
+		-configuration Release \
+		-destination "generic/platform=iOS" \
+		-archivePath dist/ios-platform \
+		-verbose \
+		| tee logs/ios-platform-build.log \
+		| xcbeautify
 
 	@echo "--- :xcode: Creating iOS Simulator Framework"
 
 	xcodebuild archive \
-	-workspace libraries/ios/WooCommerceShared.xcworkspace \
-	-scheme "WooCommerceShared" \
-	-configuration Release \
-    -destination "generic/platform=iOS Simulator" \
-	-archivePath dist/ios-simulator \
-	-verbose \
-	| tee logs/ios-simulator-build.log \
-	| xcbeautify
+		-workspace libraries/ios/WooCommerceShared.xcworkspace \
+		-scheme "WooCommerceShared" \
+		-configuration Release \
+		-destination "generic/platform=iOS Simulator" \
+		-archivePath dist/ios-simulator \
+		-verbose \
+		| tee logs/ios-simulator-build.log \
+		| xcbeautify
 
 	@echo "--- :package: Compiling XCFramework"
 
 	rm -rf dist/WooCommerceShared.xcframework
 	xcodebuild -create-xcframework \
-	    -framework dist/ios-platform.xcarchive/Products/Library/Frameworks/WooCommerceShared.framework -debug-symbols $(shell pwd)/dist/ios-platform.xcarchive/dSYMs/WooCommerceShared.framework.dSYM \
-	    -framework dist/ios-simulator.xcarchive/Products/Library/Frameworks/WooCommerceShared.framework -debug-symbols $(shell pwd)/dist/ios-simulator.xcarchive/dSYMs/WooCommerceShared.framework.dSYM \
-	    -output dist/WooCommerceShared.xcframework
+		-framework dist/ios-platform.xcarchive/Products/Library/Frameworks/WooCommerceShared.framework -debug-symbols $(shell pwd)/dist/ios-platform.xcarchive/dSYMs/WooCommerceShared.framework.dSYM \
+		-framework dist/ios-simulator.xcarchive/Products/Library/Frameworks/WooCommerceShared.framework -debug-symbols $(shell pwd)/dist/ios-simulator.xcarchive/dSYMs/WooCommerceShared.framework.dSYM \
+		-output dist/WooCommerceShared.xcframework
 
 	@echo "--- :compression: Packaging XCFramework"
 


### PR DESCRIPTION
In #1, I noticed that the `Makefile`'s indentation was inconsistent but I didn't address it because it would have been too noisy.

While waiting for CI to finish elsewhere, here's a PR that sets up [EditorConfig](https://editorconfig.org/) to ensure consistent indentation.

---

While working on this, I made an interesting find. The syntax highlighting in my Vim was not highlighting the `xcodebuild` commands:

<img alt="image" src="https://github.com/woocommerce/WooCommerce-Shared/assets/1218433/28fe7984-023a-46bf-a244-a894f1c68c45" width=300/>

At first, I thought it had to do with the commands, but it turned out to be because of the empty lines:

<img alt="image" src="https://github.com/woocommerce/WooCommerce-Shared/assets/1218433/77e443a8-2e93-455e-8a16-25bd29b004b7" width=300/>

I did some research online and I found a few sources pointing to `Makefile`'s syntax using empty lines to separate tasks and therefore there shouldn't be empty lines between tasks steps. That seems consistent with my editor's behavior. However, I couldn't find anything official. Besides, that seems quite inconvenient.