### PR TITLE
Setup for CocoaPods and SPM distribution

### DIFF
--- a/.buildkite/build-ios.sh
+++ b/.buildkite/build-ios.sh
@@ -53,3 +53,12 @@ brew install xcbeautify
 
 echo "--- :xcode: Building"
 make bundle-ios xcframework
+
+echo "--- :amazon-s3: Uploading"
+GIT_HASH=$(git rev-parse --short HEAD)
+aws s3 cp dist/WooCommerceShared.xcframework.zip s3://a8c-apps-public-artifacts/woocommerce-shared/${GIT_HASH}/WooCommerceShared.xcframework.zip
+
+echo "--- 🧮 Hashing"
+ZIP_HASH=$(swift package compute-checksum dist/WooCommerceShared.xcframework.zip)
+echo $ZIP_HASH | tee dist/WooCommerceShared.xcframework.zip.checksum.txt
+aws s3 cp dist/WooCommerceShared.xcframework.zip.checksum.txt s3://a8c-apps-public-artifacts/woocommerce-shared/${GIT_HASH}/WooCommerceShared.xcframework.zip.checksum.txt

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,6 +27,7 @@ steps:
       queue: "mac"
     artifact_paths:
       - "dist/*.tar.gz"
+      - "dist/*.zip"
       - "logs/**/*"
 
   #################

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,8 @@ xcframework:
 
 	@echo "--- :compression: Packaging XCFramework"
 
-	rm -rf dist/WooCommerceShared.xcframework.tar.gz
-	tar -czf dist/WooCommerceShared.xcframework.tar.gz -C dist/ WooCommerceShared.xcframework
+	rm -rf dist/WooCommerceShared.xcframework.zip
+	ditto -c -k --sequesterRsrc --keepParent dist/WooCommerceShared.xcframework dist/WooCommerceShared.xcframework.zip
 
 # Remove all downloaded dependencies and compiled code
 #

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ gems: bundle
 pods: gems
 	bundle exec pod install --project-directory=libraries/ios
 
+validate-pod:
+	bundle exec pod spec lint
+
 # Build an XCFramework of this project – this is the primary distribution artifact for iOS
 #
 xcframework:

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WooCommerceShared",
-            url: "https://d2twmm2nzpx3bg.cloudfront.net/woocommerce-shared/64b5ca9/WooCommerceShared.xcframework.tar.gz",
-            checksum: "aasdfasdfasdfasdfasdf"
+            url: "https://cdn.a8c-ci.services/woocommerce-shared/6cba1e9/WooCommerceShared.xcframework.zip",
+            checksum: "d815fb1b3a897e1a42c27c6ea1373ab25c818d3beaa4a73205390c6031768d1c"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "WooCommerceShared",
+    platforms: [
+       .iOS(.v13),
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "WooCommerceShared",
+            targets: ["WooCommerceShared"])
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+    ],
+    targets: [
+        .binaryTarget(
+            name: "WooCommerceShared",
+            url: "https://d2twmm2nzpx3bg.cloudfront.net/woocommerce-shared/64b5ca9/WooCommerceShared.xcframework.tar.gz",
+            checksum: "aasdfasdfasdfasdfasdf"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,40 @@
 
 A React Native project used to share code between WooCommerce iOS and Android.
 
-## Getting Started
+## Quickstart
+
+
+### iOS – SwiftPM
+
+#### Production Builds
+```swift
+dependencies: [
+    .package(url: "https://github.com/woocommerce/woocommerce-shared.git", .upToNextMajor(from: "0.0.1"))
+]
+```
+
+#### Development Builds
+```swift
+
+// Development Builds require two entries – one for the binary target:
+targets: [
+    .binaryTarget(
+        name: "WooCommerceShared",
+        url: "https://cdn.a8c-ci.services/woocommerce-shared/[commit-hash]/WooCommerceShared.xcframework.zip",
+        checksum: "[Contents of https://cdn.a8c-ci.services/woocommerce-shared/[commit-hash]/WooCommerceShared.xcframework.zip.checksum.txt]"
+    )
+
+]
+ 
+// And a second to make the target depend on it:
+    .executable(name: "MyApp", targets: [
+    	"WooCommerceShared"
+    ])
+
+```
+
+
+## Development
 
 This project uses `make` for most of its operations. You probably already have it installed if you've used your computer for development tasks in the past.
 
@@ -17,3 +50,4 @@ Run `make dev` to start working on this project locally.
 ## Build + Ship
 
 Running `make` (with no other arguments) will build every component of the project (if possible on the current machine). See the `Makefile` for all of the individual build tasks involved in this.
+

--- a/README.md
+++ b/README.md
@@ -68,3 +68,12 @@ Run `make dev` to start working on this project locally.
 
 Running `make` (with no other arguments) will build every component of the project (if possible on the current machine). See the `Makefile` for all of the individual build tasks involved in this.
 
+## Releases
+
+Because of various CocoaPods and SwiftPM idiosyncracies around `xcframework` distribution, releases are a bit tricky. To perform a release, you should:
+
+1. Create a `release/$VERSION` branch, and push it up to GitHub.com
+2. Wait for CI to publish the tip of your release branch, and note the commit shorthash.
+3. Update the URL in `Package.swift`, and update the `checksum` field with the hash printed in the build log (if you need it, it's also published to `https://cdn.a8c-ci.services/woocommerce-shared/{commit-hash}/WooCommerceShared.xcframework.zip.checksum.txt`.
+4. Commit your change as `Tag {$VERSION}`, then tag that commit with your version number.
+5. Publish the tag to GitHub.com

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ A React Native project used to share code between WooCommerce iOS and Android.
 
 ## Quickstart
 
+### iOS – CocoaPods
+
+#### Production Builds
+```ruby
+pod 'woocommerce-shared', '~> 0.0.1'
+```
+
+#### Development Builds
+```ruby
+# Reference a commit hash
+pod 'WooCommerceShared', git: 'https://github.com/woocommerce/WooCommerce-Shared.git', commit: '6cba1e9'
+
+# Reference a branch
+pod 'WooCommerceShared', git: 'https://github.com/woocommerce/WooCommerce-Shared.git', branch: 'trunk'
+
+# Reference a local copy
+pod 'WooCommerceShared', path: '../WooCommerce-Shared'
+```
 
 ### iOS – SwiftPM
 
@@ -16,7 +34,6 @@ dependencies: [
 
 #### Development Builds
 ```swift
-
 // Development Builds require two entries – one for the binary target:
 targets: [
     .binaryTarget(
@@ -28,9 +45,9 @@ targets: [
 ]
  
 // And a second to make the target depend on it:
-    .executable(name: "MyApp", targets: [
-    	"WooCommerceShared"
-    ])
+.executable(name: "MyApp", targets: [
+	"WooCommerceShared",
+])
 
 ```
 

--- a/WooCommerceShared.podspec
+++ b/WooCommerceShared.podspec
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/BlockLength
+
+Pod::Spec.new do |s|
+  s.name          = 'WooCommerceShared'
+  s.version       = '0.0.1'
+
+  s.summary       = 'Shared components used for the iOS and Android WooCommerce Apps.'
+  s.description   = s.summary + ' It\'s a React Native library project.'
+
+  s.homepage      = 'https://github.com/woocommerce/WooCommerce-Shared'
+  s.license       = { type: 'MPL', file: 'LICENSE' }
+  s.license       = { :type => 'Copyright', :text => File.read('LICENSE') }
+  s.author        = { 'The WooCommerce Mobile Team' => 'mobile@wordpress.org' }
+
+  s.platform      = :ios, '13.0'
+  s.swift_version = '5.0'
+
+  s.source = {
+    :http => 'https://cdn.a8c-ci.services/woocommerce-shared/6cba1e9/WooCommerceShared.xcframework.zip',
+    :sha1 => '22a81b12c36d643d059e61f45a44101308a2b74c'
+  }
+
+  s.vendored_frameworks = "WooCommerceShared.xcframework"
+end
+
+# rubocop:enable Metrics/BlockLength

--- a/WooCommerceShared.podspec
+++ b/WooCommerceShared.podspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-CURRENT_SHORTHASH=`git rev-parse --short HEAD`
+CURRENT_SHORTHASH = `git rev-parse --short HEAD`.freeze
 
 Pod::Spec.new do |s|
   s.name          = 'WooCommerceShared'
@@ -19,11 +19,14 @@ Pod::Spec.new do |s|
   s.source_files = 'WooCommerceShared.xcframework'
 
   s.source = {
-    http: "https://cdn.a8c-ci.services/woocommerce-shared/1b84526/WooCommerceShared.xcframework.zip",
+    http: 'https://cdn.a8c-ci.services/woocommerce-shared/1b84526/WooCommerceShared.xcframework.zip',
     sha256: '22a81b12c36d643d059e61f45a44101308a2b74c'
   }
 
-  s.prepare_command = 'curl https://cdn.a8c-ci.services/woocommerce-shared/1b84526/WooCommerceShared.xcframework.zip -o WooCommerceShared.xcframework.zip && unzip WooCommerceShared.xcframework.zip'
+  s.prepare_command = <<-CMD
+    curl https://cdn.a8c-ci.services/woocommerce-shared/1b84526/WooCommerceShared.xcframework.zip -o WooCommerceShared.xcframework.zip
+    unzip WooCommerceShared.xcframework.zip
+  CMD
 
   s.vendored_frameworks = 'WooCommerceShared.xcframework'
 end

--- a/WooCommerceShared.podspec
+++ b/WooCommerceShared.podspec
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+CURRENT_SHORTHASH=`git rev-parse --short HEAD`
+
 Pod::Spec.new do |s|
   s.name          = 'WooCommerceShared'
   s.version       = '0.0.1'
@@ -8,17 +10,20 @@ Pod::Spec.new do |s|
   s.description   = "#{s.summary} It's a React Native library project."
 
   s.homepage      = 'https://github.com/woocommerce/WooCommerce-Shared'
-  s.license       = { type: 'MPL', file: 'LICENSE' }
-  s.license       = { type: 'Copyright', text: File.read('LICENSE') }
+  # s.license       = { type: 'MPL', text: File.read('LICENSE') }
   s.author        = { 'The WooCommerce Mobile Team' => 'mobile@wordpress.org' }
 
   s.platform      = :ios, '13.0'
   s.swift_version = '5.0'
 
+  s.source_files = 'WooCommerceShared.xcframework'
+
   s.source = {
-    http: 'https://cdn.a8c-ci.services/woocommerce-shared/6cba1e9/WooCommerceShared.xcframework.zip',
-    sha1: '22a81b12c36d643d059e61f45a44101308a2b74c'
+    http: "https://cdn.a8c-ci.services/woocommerce-shared/1b84526/WooCommerceShared.xcframework.zip",
+    sha256: '22a81b12c36d643d059e61f45a44101308a2b74c'
   }
+
+  s.prepare_command = 'curl https://cdn.a8c-ci.services/woocommerce-shared/1b84526/WooCommerceShared.xcframework.zip -o WooCommerceShared.xcframework.zip && unzip WooCommerceShared.xcframework.zip'
 
   s.vendored_frameworks = 'WooCommerceShared.xcframework'
 end

--- a/WooCommerceShared.podspec
+++ b/WooCommerceShared.podspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-CURRENT_SHORTHASH = `git rev-parse --short HEAD`.freeze
+CURRENT_SHORTHASH = `git rev-parse --short HEAD`.strip!.freeze
 
 Pod::Spec.new do |s|
   s.name          = 'WooCommerceShared'
@@ -19,14 +19,13 @@ Pod::Spec.new do |s|
   s.source_files = 'WooCommerceShared.xcframework'
 
   s.source = {
-    http: 'https://cdn.a8c-ci.services/woocommerce-shared/1b84526/WooCommerceShared.xcframework.zip',
-    sha256: '22a81b12c36d643d059e61f45a44101308a2b74c'
+    http: "https://cdn.a8c-ci.services/woocommerce-shared/#{CURRENT_SHORTHASH}/WooCommerceShared.xcframework.zip"
   }
 
-  s.prepare_command = <<-CMD
-    curl https://cdn.a8c-ci.services/woocommerce-shared/1b84526/WooCommerceShared.xcframework.zip -o WooCommerceShared.xcframework.zip
-    unzip WooCommerceShared.xcframework.zip
-  CMD
+  # s.prepare_command = <<-CMD
+  #   curl https://cdn.a8c-ci.services/woocommerce-shared/1b84526/WooCommerceShared.xcframework.zip -o WooCommerceShared.xcframework.zip
+  #   unzip WooCommerceShared.xcframework.zip
+  # CMD
 
   s.vendored_frameworks = 'WooCommerceShared.xcframework'
 end

--- a/WooCommerceShared.podspec
+++ b/WooCommerceShared.podspec
@@ -4,13 +4,13 @@ CURRENT_SHORTHASH = `git rev-parse --short HEAD`.strip!.freeze
 
 Pod::Spec.new do |s|
   s.name          = 'WooCommerceShared'
-  s.version       = '0.0.1'
+  s.version       = '0.1.0'
 
   s.summary       = 'Shared components used for the iOS and Android WooCommerce Apps.'
   s.description   = "#{s.summary} It's a React Native library project."
 
   s.homepage      = 'https://github.com/woocommerce/WooCommerce-Shared'
-  # s.license       = { type: 'MPL', text: File.read('LICENSE') }
+  s.license       = { type: 'MPL', text: File.read('LICENSE') }
   s.author        = { 'The WooCommerce Mobile Team' => 'mobile@wordpress.org' }
 
   s.platform      = :ios, '13.0'
@@ -21,11 +21,6 @@ Pod::Spec.new do |s|
   s.source = {
     http: "https://cdn.a8c-ci.services/woocommerce-shared/#{CURRENT_SHORTHASH}/WooCommerceShared.xcframework.zip"
   }
-
-  # s.prepare_command = <<-CMD
-  #   curl https://cdn.a8c-ci.services/woocommerce-shared/1b84526/WooCommerceShared.xcframework.zip -o WooCommerceShared.xcframework.zip
-  #   unzip WooCommerceShared.xcframework.zip
-  # CMD
 
   s.vendored_frameworks = 'WooCommerceShared.xcframework'
 end


### PR DESCRIPTION
Adds instructions on how to use the library, as well as the Podspec and Package.swift that make it work.

Doesn't yet publish the package to CocoaPods.

SwiftPM only allows packages to be distributed as ZIP files, so this PR adjusts that.