### PR TITLE
Setup ReactActivity for Android project

### DIFF
--- a/libraries/android/build.gradle
+++ b/libraries/android/build.gradle
@@ -5,6 +5,5 @@ ext {
     // Testing
     jUnitVersion = '4.13.2'
 
-    // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
-    ndkVersion = "23.1.7779620"
+    ndkVersion = "25.2.9519653"
 }

--- a/libraries/android/build.gradle
+++ b/libraries/android/build.gradle
@@ -1,5 +1,9 @@
 ext {
     appCompatVersion = '1.4.2'
+    activityComposeVersion = '1.7.2'
+    androidxCoreVersion = '1.10.1'
+    androidxComposeBomVersion = '2022.12.00'
+    androidxComposeCompilerVersion = '1.4.4'
     reactNativeVersion = '0.71.8'
 
     // Testing

--- a/libraries/android/demo/build.gradle
+++ b/libraries/android/demo/build.gradle
@@ -8,6 +8,8 @@ repositories {
 }
 
 android {
+    ndkVersion rootProject.ext.ndkVersion
+
     namespace 'com.woocommerce.shared.demo'
     compileSdk 33
 
@@ -27,9 +29,17 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    packagingOptions {
+        // Avoid React Native's JNI duplicated classes
+        pickFirst '**/libc++_shared.so'
+        pickFirst '**/libfbjni.so'
+    }
 }
 
 dependencies {
+    implementation project(":library")
+
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
 
     testImplementation "junit:junit:$jUnitVersion"

--- a/libraries/android/demo/build.gradle
+++ b/libraries/android/demo/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
 }
 
 repositories {
@@ -23,6 +24,14 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = androidxComposeCompilerVersion
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -41,6 +50,13 @@ dependencies {
     implementation project(":library")
 
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
+    implementation "androidx.core:core-ktx:$androidxCoreVersion"
+
+    // Jetpack Compose
+    implementation "androidx.activity:activity-compose:$activityComposeVersion"
+    implementation platform("androidx.compose:compose-bom:$androidxComposeBomVersion")
+    // Dependencies managed by BOM
+    implementation 'androidx.compose.material3:material3'
 
     testImplementation "junit:junit:$jUnitVersion"
 }

--- a/libraries/android/demo/src/main/AndroidManifest.xml
+++ b/libraries/android/demo/src/main/AndroidManifest.xml
@@ -8,6 +8,16 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Android" />
+        android:theme="@style/Theme.Android" >
+
+        <activity android:name="com.woocommerce.shared.library.ReactActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+    </application>
 
 </manifest>

--- a/libraries/android/demo/src/main/AndroidManifest.xml
+++ b/libraries/android/demo/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         package="com.woocommerce.shared.demo"
@@ -8,16 +11,20 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Android" >
+        android:theme="@style/Theme.Android"
+        android:usesCleartextTraffic="true"
+        tools:targetApi="28">
 
-        <activity android:name="com.woocommerce.shared.library.ReactActivity"
+        <activity
+            android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
+        <activity
+            android:name="com.woocommerce.shared.library.ReactActivity"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
     </application>
-
 </manifest>

--- a/libraries/android/demo/src/main/kotlin/MainActivity.kt
+++ b/libraries/android/demo/src/main/kotlin/MainActivity.kt
@@ -1,0 +1,42 @@
+package com.woocommerce.shared.demo
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.woocommerce.shared.library.ReactActivity
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                )
+                {
+                    Button(onClick = {
+                        startReactActivity()
+                    }) {
+                        Text(text = "React Activity")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun startReactActivity() {
+        val intent = Intent(this@MainActivity, ReactActivity::class.java)
+        startActivity(intent)
+    }
+}

--- a/libraries/android/library/build.gradle
+++ b/libraries/android/library/build.gradle
@@ -8,6 +8,8 @@ repositories {
     google()
 }
 
+def buildAssetsFolder = 'build/assets'
+
 android {
     ndkVersion rootProject.ext.ndkVersion
 
@@ -31,6 +33,11 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+    sourceSets {
+        main {
+            assets.srcDirs += buildAssetsFolder
+        }
     }
 }
 

--- a/libraries/android/library/build.gradle
+++ b/libraries/android/library/build.gradle
@@ -44,6 +44,7 @@ android {
 dependencies {
     implementation "com.facebook.react:react-android:$reactNativeVersion"
     implementation "com.facebook.react:hermes-android:$reactNativeVersion"
+    implementation "androidx.core:core-ktx:$androidxCoreVersion"
 
     testImplementation "junit:junit:$jUnitVersion"
 }

--- a/libraries/android/library/src/main/kotlin/ReactActivity.kt
+++ b/libraries/android/library/src/main/kotlin/ReactActivity.kt
@@ -1,0 +1,64 @@
+package com.woocommerce.shared.library
+
+import android.app.Activity
+import android.os.Bundle
+import com.facebook.react.PackageList
+import com.facebook.react.ReactInstanceManager
+import com.facebook.react.ReactPackage
+import com.facebook.react.ReactRootView
+import com.facebook.react.common.LifecycleState
+import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
+import com.facebook.soloader.SoLoader
+
+class ReactActivity : Activity(), DefaultHardwareBackBtnHandler {
+    private lateinit var reactRootView: ReactRootView
+    private lateinit var reactInstanceManager: ReactInstanceManager
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        SoLoader.init(this, false)
+        reactRootView = ReactRootView(this)
+
+        val packages: List<ReactPackage> = PackageList(application).packages
+        // Packages that cannot be autolinked yet can be added manually here, for example:
+        // packages.add(MyReactNativePackage())
+        // Remember to include them in `settings.gradle` and `app/build.gradle` too.
+        reactInstanceManager = ReactInstanceManager.builder()
+            .setApplication(application)
+            .setCurrentActivity(this)
+            .setBundleAssetName("index.android.bundle")
+            .setJSMainModulePath("index")
+            .addPackages(packages)
+            .setUseDeveloperSupport(BuildConfig.DEBUG)
+            .setInitialLifecycleState(LifecycleState.RESUMED)
+            .build()
+        // The string here (e.g. "MyReactNativeApp") has to match
+        // the string in AppRegistry.registerComponent() in index.js
+        reactRootView.startReactApplication(reactInstanceManager, "main", null)
+        setContentView(reactRootView)
+    }
+
+    override fun invokeDefaultOnBackPressed() {
+        super.onBackPressed()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        reactInstanceManager.onHostPause(this)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        reactInstanceManager.onHostResume(this, this)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        reactInstanceManager.onHostDestroy(this)
+        reactRootView.unmountReactApplication()
+    }
+
+    override fun onBackPressed() {
+        reactInstanceManager.onBackPressed()
+        super.onBackPressed()
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "react": "17.0.2",
+    "react": "18.2.0",
     "react-native": "^0.71.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3501,13 +3501,12 @@ react-shallow-renderer@^16.15.0:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
 
-react@17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 readable-stream@^3.4.0:
   version "3.6.2"


### PR DESCRIPTION
This PR builds on #8 and gets the Android project in a testable state. Here is a list of changes:

* Updates `react` to `18.2.0` in d7f830020d702185814efae2dcba46e424316541. Previous to this change, when I used Metro to render the Android project, I was getting `TypeError: Cannot read property 'isBatchingLegacy' of undefined, js engine: hermes` error.
* Adds `library` Android module to `demo` Android module as a dependency in 0dadcb0be0bb35793b6bf6ecac5c122095308fff. As part of it, I updated `ndk` to latest and set up `packagingOptions` to avoid duplicate class errors.
* Adds `ReactActivity` in 323c5332d671690b730691de6478ca4d44752d1e to the library module. This is a base activity and was setup using the [relevant react-native documentation](https://reactnative.dev/docs/integration-with-existing-apps?language=kotlin#the-magic-reactrootview). As part of this commit, I've added `build/assets` folder to the source sets, so that we can package the bundled `js` file with the Android library.
* Enables kotlin & Jetpack compose for Android projects in 63bc1c9e8aab37c0f9366a52847f3f57d2166c17
* Adds a `MainActivity` to the demo module with a button that opens `ReactActivity` in 56b50f08628223e543ed7e1f60dfb065a4e46f8b. This demonstrates how we'll add this same activity to WCAndroid project.

**To Test with Bundled JS file**

* Bundle the Android JS file with `make bundle-android`
* Create the assets folder and copy the bundled JS file to it with `mkdir -p libraries/android/library/build/assets/ && cp dist/bundles/bundle-android.js libraries/android/library/build/assets/index.android.bundle`
* If you are already running the Metro server, stop it
* Run the demo app from Android Studio or by assembling it and installing it manually: ` libraries/android/gradlew -p libraries/android/ :demo:assembleDebug && adb install libraries/android/demo/build/outputs/apk/debug/demo-debug.apk`
* Tap on the `React Activity` button and verify the "Hello from React Native!" screen
* Note that if you go back and tap on the `React Activity` button again, the app crashes. I'll follow up with this issue in a later PR which might be related to app being in debug mode.

**To Test with Metro Server**
* Run `make dev` and type `a` once it's loaded to run the Android project
* Tap on the `React Activity` button and verify the "Hello from React Native!" screen
* Make a change to the "Hello from React Native!" text in `index.js`
* Type `r` in the terminal window with the Metro server
* Verify that the screen is now showing the new value
* Type `d` in the terminal window with the Metro server
* Verify that `React Native DevMenu` is shown