### PR TITLE
Check-in gradle.properties file to Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ Pods/
 .idea/
 local.properties
 build/
-gradle.properties
 
 # macOS
 .DS_Store

--- a/libraries/android/gradle.properties
+++ b/libraries/android/gradle.properties
@@ -1,0 +1,14 @@
+# DO NOT add secret credentials to this file!
+# As opposed to most of our other projects, we are checking this `gradle.properties` file to Git.
+# So, we shouldn't add any secret credentials to it.
+#
+# This project shouldn't require any secret credentials, but if it does, we can introduce
+# `secret.properties` file to handle them. Please reach out the Apps Infrastructure Team for help.
+
+android.useAndroidX=true
+android.enableJetifier=false
+
+org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.parallel=true
+org.gradle.configureondemand=true
+org.gradle.caching=true

--- a/libraries/android/gradle.properties-example
+++ b/libraries/android/gradle.properties-example
@@ -1,7 +1,0 @@
-android.useAndroidX=true
-android.enableJetifier=false
-
-org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError
-org.gradle.parallel=true
-org.gradle.configureondemand=true
-org.gradle.caching=true


### PR DESCRIPTION
Checks in `gradle.properties` file to Git so that developers can build the project as soon as they clone it. I've included instructions about not to add any secret credentials to `gradle.properties` file, so hopefully we won't have any accidents.