### PR TITLE
[Shipping Zones] Fetch API Data 

### DIFF
--- a/API/APIs.tsx
+++ b/API/APIs.tsx
@@ -1,0 +1,6 @@
+/*
+ * WPCom API versions definitions
+ */
+export enum WPComAPIVersion {
+  wcV3 = "wc/v3",
+}

--- a/API/JetpackAPI.tsx
+++ b/API/JetpackAPI.tsx
@@ -1,0 +1,21 @@
+import { WPComAPIVersion } from "./APIs";
+
+/*
+ * Utility function to create a WPCom request using the `jetpack-blogs` tunnel.
+ *
+ */
+export async function jetpackFetch(
+  apiVersion: WPComAPIVersion,
+  path: string,
+  blogId: string,
+  token: string
+) {
+  const url = `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/${blogId}/rest-api/?path=/${apiVersion}/${path}`;
+  console.log(`-- About to fetch: ${url}`); // We can delete this but seems handy for the time being to seee what requests are being fired.
+
+  return fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}

--- a/API/ShippingZoneAPI.tsx
+++ b/API/ShippingZoneAPI.tsx
@@ -1,0 +1,126 @@
+import { WPComAPIVersion } from "./APIs";
+import { jetpackFetch } from "./JetpackAPI";
+
+/*
+ * ShippingZone API defition
+ */
+export type ShippingZone = {
+  id: number;
+  title: string;
+  locations: ShippingZoneLocation[];
+  methods: ShippingZoneMethod[];
+};
+
+/*
+ * ShippingZoneLocation API defition
+ */
+export type ShippingZoneLocation = {
+  code: string;
+  type: string;
+};
+
+/*
+ * ShippingZoneMethod API defition
+ */
+export type ShippingZoneMethod = {
+  id: number;
+  title: string;
+  description: string;
+};
+
+/*
+ * Fetches shipping zones using the WPCom API.
+ * Internally fetches the necessary locations and methods too as they live in a separate API.
+ */
+export async function fetchShippingZones(blogId: string, token: string) {
+  try {
+    const response = await jetpackFetch(
+      WPComAPIVersion.wcV3,
+      "shipping/zones",
+      blogId,
+      token
+    );
+
+    const json = await response.json();
+    const zones: ShippingZone[] = await Promise.all(
+      json.data.map(async (obj) => {
+        return {
+          id: obj.id,
+          title: obj.name,
+          locations: await fetchShippingZoneLocations(obj.id, blogId, token),
+          methods: await fetchShippingZoneMethods(obj.id, blogId, token),
+        };
+      })
+    );
+
+    return zones;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+}
+
+/*
+ * Fetches shipping zones locations for a given zone id, using the WPCom API.
+ */
+export async function fetchShippingZoneLocations(
+  zoneID: number,
+  blogId: string,
+  token: string
+) {
+  try {
+    let path = `shipping/zones/${zoneID}/locations`;
+    const response = await jetpackFetch(
+      WPComAPIVersion.wcV3,
+      path,
+      blogId,
+      token
+    );
+
+    const json = await response.json();
+    const locations: ShippingZoneLocation[] = json.data.map((obj) => {
+      return {
+        code: obj.code,
+        type: obj.type,
+      };
+    });
+
+    return locations;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+}
+
+/*
+ * Fetches shipping zones methods for a given zone id, using the WPCom API.
+ */
+export async function fetchShippingZoneMethods(
+  zoneID: number,
+  blogId: string,
+  token: string
+) {
+  try {
+    let path = `shipping/zones/${zoneID}/methods`;
+    const response = await jetpackFetch(
+      WPComAPIVersion.wcV3,
+      path,
+      blogId,
+      token
+    );
+
+    const json = await response.json();
+    const methods: ShippingZoneMethod[] = json.data.map((obj) => {
+      return {
+        id: obj.method_id,
+        title: obj.method_title,
+        description: obj.method_description,
+      };
+    });
+
+    return methods;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+}

--- a/index.tsx
+++ b/index.tsx
@@ -8,24 +8,7 @@ import {
   Text,
   View,
 } from "react-native";
-
-type ShippingZone = {
-  id: number;
-  title: string;
-  locations: ShippingZoneLocation[];
-  methods: ShippingZoneMethod[];
-};
-
-type ShippingZoneLocation = {
-  code: string;
-  type: string;
-};
-
-type ShippingZoneMethod = {
-  id: number;
-  title: string;
-  description: string;
-};
+import { fetchShippingZones, ShippingZone } from "./API/ShippingZoneAPI";
 
 type RowProps = {
   title: string;
@@ -50,83 +33,10 @@ const App = (props) => {
   const fetchData = async () => {
     setLoading(true);
 
-    const zones = await getShippingZones();
-    const locations = await getShippingZoneLocations();
-    const methods = await getShippingZoneMethods();
-
-    const fullZones = zones.map((zone) => {
-      return {
-        ...zone,
-        locations: locations,
-        methods: methods,
-      };
-    });
+    const zones = await fetchShippingZones(props["blogId"], props["token"]);
 
     setLoading(false);
-    setData(fullZones);
-  };
-
-  const getShippingZones = async () => {
-    try {
-      const url = `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/${props["blogId"]}/rest-api/?path=/wc/v3/shipping/zones`;
-      const response = await fetch(url, {
-        headers: {
-          Authorization: `Bearer ${props["token"]}`,
-        },
-      });
-      const json = await response.json();
-      const zones: ShippingZone[] = json.data.map((obj) => {
-        return {
-          id: obj.id,
-          title: obj.name,
-          locations: [],
-          methods: [],
-        };
-      });
-      return zones;
-    } catch (error) {
-      console.error(error);
-      return [];
-    }
-  };
-
-  const getShippingZoneLocations = async () => {
-    try {
-      const response = await fetch(
-        "https://my-json-server.typicode.com/wzieba/FakeShipping/zone_locations"
-      );
-      const json = await response.json();
-      const locations: ShippingZoneLocation[] = json.map((obj) => {
-        return {
-          code: obj.code,
-          type: obj.type,
-        };
-      });
-      return locations;
-    } catch (error) {
-      console.error(error);
-      return [];
-    }
-  };
-
-  const getShippingZoneMethods = async () => {
-    try {
-      const response = await fetch(
-        "https://my-json-server.typicode.com/wzieba/FakeShipping/zone_methods"
-      );
-      const json = await response.json();
-      const methods: ShippingZoneMethod[] = json.map((obj) => {
-        return {
-          id: obj.method_id,
-          title: obj.method_title,
-          description: obj.method_description,
-        };
-      });
-      return methods;
-    } catch (error) {
-      console.error(error);
-      return [];
-    }
+    setData(zones);
   };
 
   useEffect(() => {


### PR DESCRIPTION
Part of #14 

# Why

This PR makes sure the shipping zones are fetched in their totality from the WPCOM API. In the process, this is my first attempt at separating some API concerns from the main `index.tsx` file.

# How

In particular, it adds:

- An `WPComAPIVersion` enum to list the possible API versions. To keep this short I'm only populating the one we are using for shipping zones

- A `jetpackFetch` function to easily build requests that are directed to the WPCom jetpack-blogs API.

- A `ShippingZoneAPI` file that exports the `fetchShippingZones` function, this function fetches the shipping zones from the API(like before) but now it fetches locations & methods for each zone and returns the complete object to the caller.

# Next

Currently, I'm passing the `blogID` and the `token` all over the place. In a Next PR I will be looking at storing those using some [async storage package](https://reactnative.dev/docs/asyncstorage)

# Demo

https://github.com/woocommerce/WooCommerce-Shared/assets/562080/67e29f3a-6a17-4b80-803c-05e036f7e268

# Testing steps

- Load the Android app on the `wzieba/react_native_playground` branch
- Navigate to Hub -> Settings -> Shipping Classes and zones
- See all the store shipping zones being loaded.