### PR TITLE
[Android] Introduce Flipper HTTP interceptor

### DIFF
--- a/libraries/android/build.gradle
+++ b/libraries/android/build.gradle
@@ -16,4 +16,5 @@ ext {
     jUnitVersion = '4.13.2'
 
     ndkVersion = "25.2.9519653"
+    flipperVersion = '0.176.1'
 }

--- a/libraries/android/library/build.gradle
+++ b/libraries/android/library/build.gradle
@@ -39,6 +39,8 @@ android {
         main {
             assets.srcDirs += buildAssetsFolder
         }
+        release.kotlin.srcDirs += 'src/release/kotlin'
+        debug.kotlin.srcDirs += 'src/debug/kotlin'
     }
 }
 

--- a/libraries/android/library/build.gradle
+++ b/libraries/android/library/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     implementation "com.facebook.react:hermes-android"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
 
+    debugImplementation "com.facebook.flipper:flipper:$flipperVersion"
+    debugImplementation "com.facebook.flipper:flipper-network-plugin:$flipperVersion"
+
     testImplementation "junit:junit:$jUnitVersion"
 }
 

--- a/libraries/android/library/src/debug/kotlin/SetupBuildSpecificDependencies.kt
+++ b/libraries/android/library/src/debug/kotlin/SetupBuildSpecificDependencies.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.shared.library
+
+import android.content.Context
+import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
+import com.facebook.react.modules.network.NetworkingModule
+
+object SetupBuildSpecificDependencies {
+
+    operator fun invoke(context: Context) {
+        val flipperInstance =
+            AndroidFlipperClient.getInstanceIfInitialized() ?: AndroidFlipperClient.getInstance(
+                context
+            ).apply {
+                addPlugin(NetworkFlipperPlugin())
+                start()
+            }
+
+        NetworkingModule.setCustomClientBuilder { builder ->
+            builder.addNetworkInterceptor(
+                FlipperOkhttpInterceptor(
+                    flipperInstance.getPlugin(NetworkFlipperPlugin.ID)
+                )
+            )
+        }
+    }
+}

--- a/libraries/android/library/src/main/kotlin/ReactActivity.kt
+++ b/libraries/android/library/src/main/kotlin/ReactActivity.kt
@@ -25,6 +25,8 @@ class ReactActivity : Activity(), DefaultHardwareBackBtnHandler {
         reactRootView = ReactRootView(this)
 
         val packages: List<ReactPackage> = PackageList(application).packages
+
+        SetupBuildSpecificDependencies(application)
         // Packages that cannot be autolinked yet can be added manually here, for example:
         // packages.add(MyReactNativePackage())
         // Remember to include them in `settings.gradle` and `app/build.gradle` too.

--- a/libraries/android/library/src/release/kotlin/SetupBuildSpecificDependencies.kt
+++ b/libraries/android/library/src/release/kotlin/SetupBuildSpecificDependencies.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.shared.library
+
+import android.content.Context
+
+object SetupBuildSpecificDependencies {
+    operator fun invoke(context: Context) = Unit
+}


### PR DESCRIPTION
Closes: #33 

### Description

This PR introduces Flipper HTTP interceptor that works in `demo` app or integrates into existing Flipper instance when integrating with `WCAndroid` app.

### Demo

https://github.com/woocommerce/WooCommerce-Shared/assets/5845095/9721372e-2e8f-4b3f-afcf-89723e8f1282

### How to test

Not necessary, but if you want to check how it works then:
- run WooCommerce-Shared as included build in `WCAndroid` repository
- run `demo` app from `WooCommerce-Shared` repository - as we don't pass credentials in such a scenario, you should see only 1 failed HTTP request logged
