### PR TITLE
Fix iOS header height

### DIFF
--- a/libraries/ios/Demo App/SceneDelegate.swift
+++ b/libraries/ios/Demo App/SceneDelegate.swift
@@ -30,10 +30,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         /// If you want to run on physical hardware, you can do that too:
         /// let viewController = WCReactNativeViewController.forOnDeviceDevelopment(withServer: "192.168.5.149", onPort: 8443)
 
-        let navigation = UINavigationController(rootViewController: viewController)
-
         /// 4. Set the root view controller of the window with your view controller
-        window.rootViewController = navigation
+        window.rootViewController = viewController
 
         /// 5. Set the window and call makeKeyAndVisible()
         self.window = window


### PR DESCRIPTION
closes #38 

# Why

This only happened on the demo app, because we were instantiating the react controller, which already has a navigation bar inside a navigation controller, which adds a second navigation bar.

Removing the navigation controller from the demo app fixes the issue.

<img width="434" alt="Screenshot 2023-06-23 at 4 17 38 PM" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/f7f608f9-ebfd-44b6-ad90-d4ffb0cae85b">
