### PR TITLE
Retry failed operations

### DIFF
--- a/API/APIs.tsx
+++ b/API/APIs.tsx
@@ -4,3 +4,24 @@
 export enum WPComAPIVersion {
   wcV3 = "wc/v3",
 }
+
+/*
+ * Defines an API error.
+ *
+ */
+export class APIError extends Error {
+  path: string;
+  statusCode: number;
+  json?: { string: any };
+
+  constructor(path: string, statusCode: number, json?: { string: any }) {
+    super(`
+    There was an error fetching: ${path} \n
+    Status Code: ${statusCode} \n
+    Response: ${JSON.stringify(json)} \n
+    `);
+    this.path = path;
+    this.statusCode = statusCode;
+    this.json = json;
+  }
+}

--- a/API/ShippingZoneAPI.tsx
+++ b/API/ShippingZoneAPI.tsx
@@ -1,4 +1,4 @@
-import { WPComAPIVersion } from "./APIs";
+import { APIError, WPComAPIVersion } from "./APIs";
 import { jetpackFetch } from "./JetpackAPI";
 
 /*
@@ -34,9 +34,14 @@ export type ShippingZoneMethod = {
  */
 export async function fetchShippingZones() {
   try {
-    const response = await jetpackFetch(WPComAPIVersion.wcV3, "shipping/zones");
-
+    const path = "shipping/zones";
+    const response = await jetpackFetch(WPComAPIVersion.wcV3, path);
     const json = await response.json();
+
+    if (!response.ok) {
+      throw new APIError(path, response.status, json);
+    }
+
     const zones: ShippingZone[] = await Promise.all(
       json.data.map(async (obj) => {
         return {
@@ -50,8 +55,7 @@ export async function fetchShippingZones() {
 
     return zones;
   } catch (error) {
-    console.error(error);
-    return [];
+    throw error;
   }
 }
 
@@ -62,8 +66,12 @@ export async function fetchShippingZoneLocations(zoneID: number) {
   try {
     let path = `shipping/zones/${zoneID}/locations`;
     const response = await jetpackFetch(WPComAPIVersion.wcV3, path);
-
     const json = await response.json();
+
+    if (!response.ok) {
+      throw new APIError(path, response.status, json);
+    }
+
     const locations: ShippingZoneLocation[] = json.data.map((obj) => {
       return {
         code: obj.code,
@@ -73,8 +81,7 @@ export async function fetchShippingZoneLocations(zoneID: number) {
 
     return locations;
   } catch (error) {
-    console.error(error);
-    return [];
+    throw error;
   }
 }
 
@@ -85,8 +92,12 @@ export async function fetchShippingZoneMethods(zoneID: number) {
   try {
     let path = `shipping/zones/${zoneID}/methods`;
     const response = await jetpackFetch(WPComAPIVersion.wcV3, path);
-
     const json = await response.json();
+
+    if (!response.ok) {
+      throw new APIError(path, response.status, json);
+    }
+
     const methods: ShippingZoneMethod[] = json.data.map((obj) => {
       return {
         id: obj.method_id,
@@ -97,7 +108,6 @@ export async function fetchShippingZoneMethods(zoneID: number) {
 
     return methods;
   } catch (error) {
-    console.error(error);
-    return [];
+    throw error;
   }
 }

--- a/ShippingZones.tsx
+++ b/ShippingZones.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   Text,
   View,
+  Alert,
 } from "react-native";
 import React, { useEffect, useState } from "react";
 import { fetchShippingZones, ShippingZone } from "./API/ShippingZoneAPI";
@@ -33,15 +34,38 @@ const ShippingZonesList = () => {
   const [data, setData] = useState<ShippingZone[]>([]);
 
   /*
+   * Shows an alert that allows the user to retry the fetch operation.
+   */
+  const showRetryAlert = () => {
+    Alert.alert(
+      "",
+      "There was an error loading shipping zones, pleae try again later.",
+      [
+        {
+          text: "Cancel",
+          style: "cancel",
+        },
+        { text: "Retry", onPress: () => fetchData() },
+      ]
+    );
+  };
+
+  /*
    * Fetches the neccessary data for the shipping zones list.
+   * If the operation fails, a retry alert is shown.
    */
   const fetchData = async () => {
     setLoading(true);
 
-    const zones = await fetchShippingZones();
+    try {
+      const zones = await fetchShippingZones();
+      setData(zones);
+    } catch (error) {
+      console.log(error);
+      showRetryAlert();
+    }
 
     setLoading(false);
-    setData(zones);
   };
 
   useEffect(() => {


### PR DESCRIPTION
closes #20 

# Why

In order to allow users to recover from errors, this PR adds a retry alert when a network operation occurrs.

# How

- Define a new `APIError` type.
- Show a retry alert when an error happens.

# Discussion

I think showing an alert is fine for now. We can look at porting the alert/toast in the future.

# Screenshots

iOS | Android
---- | ----
<img width="432" alt="iOS" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/9e547527-249d-47f0-8ea8-dae934c63601"> |  <img width="422" alt="android" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/83f0ee03-84ce-4cc0-8884-283ea9f5ef7c">
