### PR TITLE
Idea: Tracks from Native client.

### DIFF
--- a/ShippingZones.tsx
+++ b/ShippingZones.tsx
@@ -15,7 +15,7 @@ import ToolbarActionButton from "./ToolbarActionButton";
 import { NativeModules } from 'react-native';
 
 const sendAnalyticsEvent = (event) => {
-  NativeModules.MyReactNativeBridge.sendEvent(event);
+  NativeModules.AnalyticsModule.sendEvent(event);
 };
 
 

--- a/ShippingZones.tsx
+++ b/ShippingZones.tsx
@@ -12,6 +12,12 @@ import { fetchShippingZones, ShippingZone } from "./API/ShippingZoneAPI";
 import { useNavigation } from "@react-navigation/native";
 import { NavigationRoutes } from "./Navigation/NavigationRoutes";
 import ToolbarActionButton from "./ToolbarActionButton";
+import { NativeModules } from 'react-native';
+
+const sendAnalyticsEvent = (event) => {
+  NativeModules.MyReactNativeBridge.sendEvent(event);
+};
+
 
 type RowProps = {
   title: string;
@@ -60,6 +66,7 @@ const ShippingZonesList = () => {
     try {
       const zones = await fetchShippingZones();
       setData(zones);
+      sendAnalyticsEvent('shipping_zones_shown');
     } catch (error) {
       console.log(error);
       showRetryAlert();

--- a/libraries/android/demo/src/main/AndroidManifest.xml
+++ b/libraries/android/demo/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <application
         package="com.woocommerce.shared.demo"
+        android:name=".DemoApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/libraries/android/demo/src/main/kotlin/DemoApplication.kt
+++ b/libraries/android/demo/src/main/kotlin/DemoApplication.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.shared.demo
+
+import android.app.Application
+import android.util.Log
+import com.woocommerce.shared.library.AnalyticsBridge
+import com.woocommerce.shared.library.LibraryDependencyProvider
+
+class DemoApplication : Application(), LibraryDependencyProvider {
+    override fun provideAnalyticsBridge(): AnalyticsBridge {
+        return object : AnalyticsBridge {
+            override fun sendEvent(event: String) {
+                Log.d("Tracks", "Sending fake event: $event")
+            }
+        }
+    }
+}

--- a/libraries/android/library/src/main/kotlin/AnalyticsBridge.kt
+++ b/libraries/android/library/src/main/kotlin/AnalyticsBridge.kt
@@ -1,0 +1,5 @@
+package com.woocommerce.shared.library
+
+interface AnalyticsBridge {
+    fun sendEvent(event: String)
+}

--- a/libraries/android/library/src/main/kotlin/LibraryDependencyProvider.kt
+++ b/libraries/android/library/src/main/kotlin/LibraryDependencyProvider.kt
@@ -1,0 +1,5 @@
+package com.woocommerce.shared.library
+
+interface LibraryDependencyProvider {
+    fun provideAnalyticsBridge(): AnalyticsBridge
+}

--- a/libraries/android/library/src/main/kotlin/ReactActivity.kt
+++ b/libraries/android/library/src/main/kotlin/ReactActivity.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.shared.library
 
-import android.app.Activity
+import WooReactNativePackage
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.PackageList
@@ -25,7 +25,10 @@ class ReactActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
         SoLoader.init(this, false)
         reactRootView = ReactRootView(this)
 
-        val packages: List<ReactPackage> = PackageList(application).packages
+        val analyticsBridge = (application as LibraryDependencyProvider).provideAnalyticsBridge()
+        val analyticsPackage = WooReactNativePackage(analyticsBridge)
+
+        val packages: List<ReactPackage> = PackageList(application).packages + analyticsPackage
 
         SetupBuildSpecificDependencies(application)
         // Packages that cannot be autolinked yet can be added manually here, for example:

--- a/libraries/android/library/src/main/kotlin/ReactNativeAnalyticsModule.kt
+++ b/libraries/android/library/src/main/kotlin/ReactNativeAnalyticsModule.kt
@@ -3,13 +3,13 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.woocommerce.shared.library.AnalyticsBridge
 
-class WooReactNativeBridge(
-    private val reactContext: ReactApplicationContext,
+class ReactNativeAnalyticsModule(
+    reactContext: ReactApplicationContext,
     private val analyticsBridge: AnalyticsBridge,
 ) : ReactContextBaseJavaModule(reactContext) {
 
     override fun getName(): String {
-        return "WooReactNativeBridge"
+        return "AnalyticsModule"
     }
 
     @ReactMethod

--- a/libraries/android/library/src/main/kotlin/WooReactNativeBridge.kt
+++ b/libraries/android/library/src/main/kotlin/WooReactNativeBridge.kt
@@ -1,0 +1,19 @@
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.woocommerce.shared.library.AnalyticsBridge
+
+class WooReactNativeBridge(
+    private val reactContext: ReactApplicationContext,
+    private val analyticsBridge: AnalyticsBridge,
+) : ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName(): String {
+        return "WooReactNativeBridge"
+    }
+
+    @ReactMethod
+    fun sendEvent(event: String) {
+        analyticsBridge.sendEvent(event)
+    }
+}

--- a/libraries/android/library/src/main/kotlin/WooReactNativePackage.kt
+++ b/libraries/android/library/src/main/kotlin/WooReactNativePackage.kt
@@ -1,0 +1,15 @@
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+import com.woocommerce.shared.library.AnalyticsBridge
+
+class WooReactNativePackage(private val analyticsBridge: AnalyticsBridge) : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return listOf(WooReactNativeBridge(reactContext, analyticsBridge))
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return emptyList()
+    }
+}

--- a/libraries/android/library/src/main/kotlin/WooReactNativePackage.kt
+++ b/libraries/android/library/src/main/kotlin/WooReactNativePackage.kt
@@ -6,7 +6,7 @@ import com.woocommerce.shared.library.AnalyticsBridge
 
 class WooReactNativePackage(private val analyticsBridge: AnalyticsBridge) : ReactPackage {
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
-        return listOf(WooReactNativeBridge(reactContext, analyticsBridge))
+        return listOf(ReactNativeAnalyticsModule(reactContext, analyticsBridge))
     }
 
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {

--- a/libraries/ios/Demo App/WCReactNativeViewController+MetroServer.swift
+++ b/libraries/ios/Demo App/WCReactNativeViewController+MetroServer.swift
@@ -25,13 +25,22 @@ struct DevServerURL {
     }
 }
 
+class FakeAnalyticsProvider: WCRNAnalyticsProvider {
+    func sendEvent(_ event: String) {
+        print("Sending fake event: \(event)")
+    }
+}
+
 extension WCReactNativeViewController {
 
     /// Returns a View Controller that allows running a simulator debug build that can connect to the metro server.
     ///
     ///
     static func forLocalDevelopment(onPort port: UInt16 = 8081) -> WCReactNativeViewController {
-        WCReactNativeViewController(bundle: DevServerURL.from(hostname: "localhost", port: port))
+        WCReactNativeViewController(bundle: DevServerURL.from(hostname: "localhost", port: port),
+                                    analyticsProvider: FakeAnalyticsProvider(),
+                                    blogID: <#blogid#>,
+                                    apiToken: <#token#>)
     }
 
     /// Create a View Controller that allows running an on-device debug build that can connect to the metro server.
@@ -41,7 +50,10 @@ extension WCReactNativeViewController {
         withServer ipAddress: IPv4Address,
         onPort port: UInt16 = 8081
     ) -> WCReactNativeViewController {
-        WCReactNativeViewController(bundle: DevServerURL.from(hostname: ipAddress.debugDescription, port: port))
+        WCReactNativeViewController(bundle: DevServerURL.from(hostname: ipAddress.debugDescription, port: port),
+                                    analyticsProvider: FakeAnalyticsProvider(),
+                                    blogID: <#blogid#>,
+                                    apiToken: <#token#>)
     }
 }
 

--- a/libraries/ios/WooCommerceShared.xcodeproj/project.pbxproj
+++ b/libraries/ios/WooCommerceShared.xcodeproj/project.pbxproj
@@ -21,6 +21,11 @@
 		2478B0C02A0AED7700E91CDF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2478B0BF2A0AED7700E91CDF /* SceneDelegate.swift */; };
 		2478B0E22A0B01CB00E91CDF /* bundle-ios.js in Resources */ = {isa = PBXBuildFile; fileRef = 2478B0E12A0B01CB00E91CDF /* bundle-ios.js */; };
 		24D35CDA2A37D2E60072EAFA /* WCReactNativeViewController+MetroServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D35CD92A37D2E60072EAFA /* WCReactNativeViewController+MetroServer.swift */; };
+		2649E1CA2A4BF5F200C1D00C /* WCRNAnalyticsModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 2649E1C92A4BF5F200C1D00C /* WCRNAnalyticsModule.m */; };
+		2690D6362A4C11A100D025DE /* WCRNAnalyticsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2649E1CC2A4C107000C1D00C /* WCRNAnalyticsProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2690D6372A4C11A400D025DE /* WCRNAnalyticsModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 2649E1C82A4BF57500C1D00C /* WCRNAnalyticsModule.h */; };
+		2690D63A2A4C170600D025DE /* WCRNBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 2690D6392A4C170300D025DE /* WCRNBridge.h */; };
+		2690D63C2A4C178F00D025DE /* WCRNBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 2690D63B2A4C178F00D025DE /* WCRNBridge.m */; };
 		DA27D9F570F33985E7E43E40 /* Pods_WooCommerceShared_WooCommerceSharedTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 339BD0CA04E906921968A56B /* Pods_WooCommerceShared_WooCommerceSharedTests.framework */; };
 		E8E437A2259ABB6D74143413 /* Pods_WooCommerceShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C3DE3FD68E0CD0385BE226A5 /* Pods_WooCommerceShared.framework */; };
 /* End PBXBuildFile section */
@@ -73,6 +78,11 @@
 		2478B0E12A0B01CB00E91CDF /* bundle-ios.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "bundle-ios.js"; path = "../../../dist/bundles/bundle-ios.js"; sourceTree = "<group>"; };
 		24C4BDA02A0BF09E00276FCB /* OpenSSL.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OpenSSL.xcframework; path = "Pods/OpenSSL-Universal/Frameworks/OpenSSL.xcframework"; sourceTree = "<group>"; };
 		24D35CD92A37D2E60072EAFA /* WCReactNativeViewController+MetroServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCReactNativeViewController+MetroServer.swift"; sourceTree = "<group>"; };
+		2649E1C82A4BF57500C1D00C /* WCRNAnalyticsModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WCRNAnalyticsModule.h; sourceTree = "<group>"; };
+		2649E1C92A4BF5F200C1D00C /* WCRNAnalyticsModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WCRNAnalyticsModule.m; sourceTree = "<group>"; };
+		2649E1CC2A4C107000C1D00C /* WCRNAnalyticsProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WCRNAnalyticsProvider.h; sourceTree = "<group>"; };
+		2690D6392A4C170300D025DE /* WCRNBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WCRNBridge.h; sourceTree = "<group>"; };
+		2690D63B2A4C178F00D025DE /* WCRNBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WCRNBridge.m; sourceTree = "<group>"; };
 		310F006D69BC062205EDD9A4 /* Pods-WooCommerceShared.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceShared.release.xcconfig"; path = "Target Support Files/Pods-WooCommerceShared/Pods-WooCommerceShared.release.xcconfig"; sourceTree = "<group>"; };
 		339BD0CA04E906921968A56B /* Pods_WooCommerceShared_WooCommerceSharedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceShared_WooCommerceSharedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		840EBAB6F5991FF94DBE2653 /* Pods-WooCommerceShared-WooCommerceSharedTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceShared-WooCommerceSharedTests.debug.xcconfig"; path = "Target Support Files/Pods-WooCommerceShared-WooCommerceSharedTests/Pods-WooCommerceShared-WooCommerceSharedTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -150,6 +160,8 @@
 				2478B04C2A0ACA6600E91CDF /* WooCommerceShared.docc */,
 				2478B0642A0ACEC000E91CDF /* WCReactNativeViewController.h */,
 				2478B0652A0ACEC000E91CDF /* WCReactNativeViewController.m */,
+				2690D6382A4C16EF00D025DE /* Bridge */,
+				2649E1CB2A4C103200C1D00C /* Analytics */,
 				2478B0E12A0B01CB00E91CDF /* bundle-ios.js */,
 			);
 			path = WooCommerceShared;
@@ -184,6 +196,25 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
+		2649E1CB2A4C103200C1D00C /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				2649E1CC2A4C107000C1D00C /* WCRNAnalyticsProvider.h */,
+				2649E1C82A4BF57500C1D00C /* WCRNAnalyticsModule.h */,
+				2649E1C92A4BF5F200C1D00C /* WCRNAnalyticsModule.m */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
+		2690D6382A4C16EF00D025DE /* Bridge */ = {
+			isa = PBXGroup;
+			children = (
+				2690D6392A4C170300D025DE /* WCRNBridge.h */,
+				2690D63B2A4C178F00D025DE /* WCRNBridge.m */,
+			);
+			path = Bridge;
+			sourceTree = "<group>";
+		};
 		37E6C0EA6F3F8FF45977AE4A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -203,6 +234,9 @@
 			files = (
 				2478B0592A0ACA6600E91CDF /* WooCommerceShared.h in Headers */,
 				2478B0662A0ACEC000E91CDF /* WCReactNativeViewController.h in Headers */,
+				2690D6362A4C11A100D025DE /* WCRNAnalyticsProvider.h in Headers */,
+				2690D6372A4C11A400D025DE /* WCRNAnalyticsModule.h in Headers */,
+				2690D63A2A4C170600D025DE /* WCRNBridge.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -425,6 +459,8 @@
 			files = (
 				2478B0672A0ACEC000E91CDF /* WCReactNativeViewController.m in Sources */,
 				2478B04D2A0ACA6600E91CDF /* WooCommerceShared.docc in Sources */,
+				2690D63C2A4C178F00D025DE /* WCRNBridge.m in Sources */,
+				2649E1CA2A4BF5F200C1D00C /* WCRNAnalyticsModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/libraries/ios/WooCommerceShared/Analytics/WCRNAnalyticsModule.h
+++ b/libraries/ios/WooCommerceShared/Analytics/WCRNAnalyticsModule.h
@@ -1,0 +1,15 @@
+#import <React/RCTBridgeModule.h>
+#import "WCRNAnalyticsProvider.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Analytics Native Module.
+/// Here we get the RN invocation and dispatch it to our analytics provider.
+///
+@interface WCRNAnalyticsModule : NSObject <RCTBridgeModule>
+
+-(instancetype)initWithProvider:(id<WCRNAnalyticsProvider>) provider;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/libraries/ios/WooCommerceShared/Analytics/WCRNAnalyticsModule.m
+++ b/libraries/ios/WooCommerceShared/Analytics/WCRNAnalyticsModule.m
@@ -1,0 +1,25 @@
+#import "WCRNAnalyticsModule.h"
+#import <React/RCTLog.h>
+
+@interface WCRNAnalyticsModule ()
+
+@property(nonatomic, strong) id<WCRNAnalyticsProvider> provider;
+
+@end
+
+@implementation WCRNAnalyticsModule
+
+RCT_EXPORT_MODULE(MyReactNativeBridge);
+
+-(instancetype)initWithProvider:(id<WCRNAnalyticsProvider>) provider {
+    if (self = [super init]) {
+        self.provider = provider;
+    }
+    return self;
+}
+
+RCT_EXPORT_METHOD(sendEvent:(NSString *)event) {
+    [self.provider sendEvent:event];
+}
+
+@end

--- a/libraries/ios/WooCommerceShared/Analytics/WCRNAnalyticsModule.m
+++ b/libraries/ios/WooCommerceShared/Analytics/WCRNAnalyticsModule.m
@@ -9,7 +9,7 @@
 
 @implementation WCRNAnalyticsModule
 
-RCT_EXPORT_MODULE(MyReactNativeBridge);
+RCT_EXPORT_MODULE(AnalyticsModule);
 
 -(instancetype)initWithProvider:(id<WCRNAnalyticsProvider>) provider {
     if (self = [super init]) {

--- a/libraries/ios/WooCommerceShared/Analytics/WCRNAnalyticsProvider.h
+++ b/libraries/ios/WooCommerceShared/Analytics/WCRNAnalyticsProvider.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Analytics Provider Protocol. This will be implemented by the host app to delegate the track duties.
+///
+@protocol WCRNAnalyticsProvider
+-(void)sendEvent:(NSString *)event;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/libraries/ios/WooCommerceShared/Bridge/WCRNBridge.h
+++ b/libraries/ios/WooCommerceShared/Bridge/WCRNBridge.h
@@ -1,0 +1,14 @@
+#import <React/RCTBridgeDelegate.h>
+#import "WCRNAnalyticsProvider.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Custom bridge. Needed to inject the Analytics Native module with injected Analytics provider.
+///
+@interface WCRNBridge : NSObject<RCTBridgeDelegate>
+
+-(instancetype)initWithBundleURL:(NSURL *)bundleURL analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/libraries/ios/WooCommerceShared/Bridge/WCRNBridge.m
+++ b/libraries/ios/WooCommerceShared/Bridge/WCRNBridge.m
@@ -1,0 +1,31 @@
+#import "WCRNBridge.h"
+#import "WCRNAnalyticsModule.h"
+
+@interface WCRNBridge ()
+
+@property(nonatomic, strong) NSURL* bundleURL;
+@property(nonatomic, strong) id<WCRNAnalyticsProvider> analyticsProvider;
+
+@end
+
+@implementation WCRNBridge
+
+-(instancetype)initWithBundleURL:(NSURL *)bundleURL analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider {
+    if (self = [super init]) {
+        self.bundleURL = bundleURL;
+        self.analyticsProvider = analyticsProvider;
+    }
+    return self;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+    return self.bundleURL;
+}
+
+-(NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge {
+    return @[
+        [[WCRNAnalyticsModule alloc] initWithProvider: self.analyticsProvider]
+    ];
+}
+
+@end

--- a/libraries/ios/WooCommerceShared/WCReactNativeViewController.h
+++ b/libraries/ios/WooCommerceShared/WCReactNativeViewController.h
@@ -4,7 +4,11 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WCReactNativeViewController : UIViewController
--(instancetype)init;
+
+-(instancetype)initWithAnalyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
+                                  blogID:(NSString *)blogId
+                                apiToken: (NSString*) apiToken;
+
 -(instancetype)initWithBundle:(NSURL *) url
             analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
                        blogID:(NSString *)blogId

--- a/libraries/ios/WooCommerceShared/WCReactNativeViewController.h
+++ b/libraries/ios/WooCommerceShared/WCReactNativeViewController.h
@@ -1,10 +1,14 @@
 #import <UIKit/UIKit.h>
+#import "WCRNAnalyticsProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WCReactNativeViewController : UIViewController
 -(instancetype)init;
--(instancetype)initWithBundle:(NSURL *) url;
+-(instancetype)initWithBundle:(NSURL *) url
+            analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
+                       blogID:(NSString *)blogId
+                     apiToken: (NSString*) apiToken;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libraries/ios/WooCommerceShared/WCReactNativeViewController.m
+++ b/libraries/ios/WooCommerceShared/WCReactNativeViewController.m
@@ -64,10 +64,10 @@
 }
 
 - (void) loadView {
-    NSDictionary * launchOptions = @{@"blogId": self.blogId, @"apiToken": self.apiToken};
+    NSDictionary * initialProps = @{@"blogId": self.blogId, @"token": self.apiToken};
     WCRNBridge * delegate = [[WCRNBridge alloc] initWithBundleURL:self.bundleUrl analyticsProvider:self.analyticsProvider];
-    RCTBridge * bridge = [[RCTBridge alloc] initWithDelegate:delegate launchOptions:launchOptions];
-    self.view = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:[NSDictionary new]];
+    RCTBridge * bridge = [[RCTBridge alloc] initWithDelegate:delegate launchOptions:[NSDictionary new]];
+    self.view = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:initialProps];
 }
 
 @end

--- a/libraries/ios/WooCommerceShared/WCReactNativeViewController.m
+++ b/libraries/ios/WooCommerceShared/WCReactNativeViewController.m
@@ -1,9 +1,14 @@
 #import "WCReactNativeViewController.h"
 #import <React/React-Core-umbrella.h>
 #import <React/RCTRootView.h>
+#import "WCRNAnalyticsProvider.h"
+#import "WCRNBridge.h"
 
 @interface WCReactNativeViewController ()
-@property(atomic, retain) NSURL* bundleUrl;
+@property(atomic, strong) NSURL* bundleUrl;
+@property(atomic, strong) NSString* blogId;
+@property(atomic, strong) NSString* apiToken;
+@property(atomic, strong) id<WCRNAnalyticsProvider> analyticsProvider;
 @end
 
 @implementation WCReactNativeViewController
@@ -33,20 +38,36 @@
     return self;
 }
 
-- (instancetype)initWithBundle:(NSURL *)url {
-    if(self = [super init]) {
-        self.bundleUrl = url;
+-(instancetype)initWithAnalyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
+                                  blogID:(NSString *)blogId
+                                apiToken: (NSString*) apiToken {
+    if (self = [self init]) {
+        self.analyticsProvider = analyticsProvider;
+        self.blogId =  blogId;
+        self.apiToken = apiToken;
     }
+    return self;
 
+}
+
+-(instancetype)initWithBundle:(NSURL *) url
+            analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
+                       blogID:(NSString *)blogId
+                     apiToken: (NSString*) apiToken {
+    if (self = [super init]) {
+        self.bundleUrl = url;
+        self.analyticsProvider = analyticsProvider;
+        self.blogId =  blogId;
+        self.apiToken = apiToken;
+    }
     return self;
 }
 
 - (void) loadView {
-    self.view = [[RCTRootView alloc] initWithBundleURL: self.bundleUrl
-                                            moduleName: @"main"
-                                     initialProperties: [NSDictionary new]
-                                         launchOptions: [NSDictionary new]
-    ];
+    NSDictionary * launchOptions = @{@"blogId": self.blogId, @"apiToken": self.apiToken};
+    WCRNBridge * delegate = [[WCRNBridge alloc] initWithBundleURL:self.bundleUrl analyticsProvider:self.analyticsProvider];
+    RCTBridge * bridge = [[RCTBridge alloc] initWithDelegate:delegate launchOptions:launchOptions];
+    self.view = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:[NSDictionary new]];
 }
 
 @end

--- a/libraries/ios/WooCommerceShared/WooCommerceShared.h
+++ b/libraries/ios/WooCommerceShared/WooCommerceShared.h
@@ -9,3 +9,4 @@ FOUNDATION_EXPORT const unsigned char WooCommerceSharedVersionString[];
 // In this header, you should import all the public headers of your framework using statements like #import <WooCommerceShared/PublicHeader.h>
 
 #import <WooCommerceShared/WCReactNativeViewController.h>
+#import <WooCommerceShared/WCRNAnalyticsProvider.h>


### PR DESCRIPTION
Closes: #17 

@Ecarrion this PR allows clients to integrate sending Tracks event from React classes via native clients Tracks implementations.

In the case of Android, injection of class that satisfies `AnalyticsBridge` interface happens [here](https://github.com/woocommerce/WooCommerce-Shared/compare/issue/17-tracks_from_native_client?expand=1#diff-119b0677854bb809b846ccb122635a04a9aea8ff40a8e44eadb32d952188a043R28) - we route dependencies via `Application` class, with which every `Activity` (including `ReactActivity`) can communicate.

Could you please verify if this solution is feasible for iOS?