### PR TITLE
Update Shipping Zone List UI

### DIFF
--- a/API/ShippingZoneAPI.tsx
+++ b/API/ShippingZoneAPI.tsx
@@ -1,3 +1,4 @@
+import { getZoneName } from "../Utils/Country";
 import { APIError, WPComAPIVersion } from "./APIs";
 import { jetpackFetch } from "./JetpackAPI";
 
@@ -16,6 +17,7 @@ export type ShippingZone = {
  */
 export type ShippingZoneLocation = {
   code: string;
+  name: string;
   type: string;
 };
 
@@ -75,6 +77,7 @@ export async function fetchShippingZoneLocations(zoneID: number) {
     const locations: ShippingZoneLocation[] = json.data.map((obj) => {
       return {
         code: obj.code,
+        name: getZoneName(obj.code),
         type: obj.type,
       };
     });

--- a/ShippingZones.tsx
+++ b/ShippingZones.tsx
@@ -22,9 +22,19 @@ type RowProps = {
 function Row(props: RowProps): JSX.Element {
   return (
     <View style={styles.row}>
-      <Text style={styles.row.title}> {props.title} </Text>
-      <Text style={styles.row.body}> {props.body} </Text>
-      <Text style={styles.row.caption}> {props.caption} </Text>
+      <View style={styles.row.content}>
+        <View style={styles.row.textContainer}>
+          <Text style={styles.row.title}> {props.title} </Text>
+          {props.body.length > 0 && (
+            <Text style={styles.row.body}> {props.body} </Text>
+          )}
+          {props.caption.length > 0 && (
+            <Text style={styles.row.caption}> {props.caption} </Text>
+          )}
+        </View>
+        <Text style={styles.row.disclosureIndicator}>›</Text>
+      </View>
+      <View style={styles.row.separator} />
     </View>
   );
 }
@@ -85,25 +95,14 @@ const ShippingZonesList = () => {
     });
   }, [navigation]);
 
-  const separator = () => (
-    <View
-      style={{
-        backgroundColor: "#CED0CE",
-        height: 0.5,
-        marginLeft: 16,
-      }}
-    />
-  );
-
   return (
     <View style={styles.container}>
       {isLoading ? (
         <SafeAreaView>
-          <ActivityIndicator />
+          <ActivityIndicator style={styles.list.loadingIndicator} />
         </SafeAreaView>
       ) : (
         <FlatList
-          ItemSeparatorComponent={separator}
           contentInsetAdjustmentBehavior="always"
           style={styles.list}
           data={data}
@@ -120,35 +119,56 @@ const ShippingZonesList = () => {
     </View>
   );
 };
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
   list: {
-    //backgroundColor: "rgb(246, 247, 247)",
     backgroundColor: "white",
+    loadingIndicator: {
+      marginTop: 32,
+    },
   },
   row: {
-    padding: 0,
-    fontSize: 23,
-    borderRadius: 0,
-    backgroundColor: "white",
-    margin: 16,
+    flex: 1,
+    content: {
+      flexDirection: "row",
+      alignItems: "center",
+      padding: 0,
+      fontSize: 23,
+      borderRadius: 0,
+      backgroundColor: "white",
+      margin: 16,
+    },
+    textContainer: {
+      flex: 1,
+    },
     title: {
       fontFamily: "System",
       fontSize: 17,
-      marginBottom: 4,
+      marginBottom: 6,
       color: "rgb(0, 0, 0)",
     },
     body: {
       fontFamily: "System",
       fontSize: 15,
+      marginBottom: 6,
       color: "rgba(0, 0, 0, 0.6)",
     },
     caption: {
       fontFamily: "System",
       fontSize: 15,
       color: "rgba(0, 0, 0, 0.6)",
+    },
+    disclosureIndicator: {
+      fontSize: 32,
+      color: "rgb(103, 67, 153)",
+    },
+    separator: {
+      backgroundColor: "rgba(60, 60, 67, 0.29)",
+      height: 0.5,
+      marginLeft: 16,
     },
   },
 });

--- a/ShippingZones.tsx
+++ b/ShippingZones.tsx
@@ -109,7 +109,7 @@ const ShippingZonesList = () => {
           renderItem={({ item }) => (
             <Row
               title={item.title}
-              body={item.locations.map((location) => location.code).join(", ")}
+              body={item.locations.map((location) => location.name).join(", ")}
               caption={item.methods.map((method) => method.title).join(", ")}
             />
           )}

--- a/ShippingZones.tsx
+++ b/ShippingZones.tsx
@@ -85,6 +85,16 @@ const ShippingZonesList = () => {
     });
   }, [navigation]);
 
+  const separator = () => (
+    <View
+      style={{
+        backgroundColor: "#CED0CE",
+        height: 0.5,
+        marginLeft: 16,
+      }}
+    />
+  );
+
   return (
     <View style={styles.container}>
       {isLoading ? (
@@ -93,14 +103,15 @@ const ShippingZonesList = () => {
         </SafeAreaView>
       ) : (
         <FlatList
+          ItemSeparatorComponent={separator}
           contentInsetAdjustmentBehavior="always"
           style={styles.list}
           data={data}
           renderItem={({ item }) => (
             <Row
               title={item.title}
-              body={item.locations.map((location) => location.code).join(" - ")}
-              caption={item.methods.map((method) => method.title).join(" - ")}
+              body={item.locations.map((location) => location.code).join(", ")}
+              caption={item.methods.map((method) => method.title).join(", ")}
             />
           )}
           keyExtractor={(item) => item.id}
@@ -114,15 +125,15 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   list: {
-    backgroundColor: "rgb(246, 247, 247)",
+    //backgroundColor: "rgb(246, 247, 247)",
+    backgroundColor: "white",
   },
   row: {
-    padding: 16,
+    padding: 0,
     fontSize: 23,
-    borderRadius: 16,
+    borderRadius: 0,
     backgroundColor: "white",
     margin: 16,
-    marginTop: 0,
     title: {
       fontFamily: "System",
       fontSize: 17,
@@ -131,12 +142,12 @@ const styles = StyleSheet.create({
     },
     body: {
       fontFamily: "System",
-      fontSize: 14,
+      fontSize: 15,
       color: "rgba(0, 0, 0, 0.6)",
     },
     caption: {
       fontFamily: "System",
-      fontSize: 12,
+      fontSize: 15,
       color: "rgba(0, 0, 0, 0.6)",
     },
   },

--- a/Utils/Country.tsx
+++ b/Utils/Country.tsx
@@ -1,0 +1,43 @@
+import { Country, State } from "country-state-city";
+
+/*
+ * Returns the zone name for a country or region.
+ * Returns an empty string for an unknown country, region or format.
+ * Supported formats:
+ * - {CountryCode}
+ * - {CountryCode:RegionCode}
+ * - {CountryCode:CountryCode-RegionCode}
+ */
+export function getZoneName(countryOrRegion: string) {
+  const zoneComponents = countryOrRegion.split(":");
+
+  // Handles the {CountryCode} format
+  if (zoneComponents.length == 1) {
+    const country = Country.getCountryByCode(zoneComponents[0]);
+    return country?.name ?? "";
+  }
+
+  if (zoneComponents.length == 2) {
+    const stateComponents = zoneComponents[1].split("-");
+
+    // Handles de {CountryCode:RegionCode} format
+    if (stateComponents.length == 1) {
+      const state = State.getStateByCodeAndCountry(
+        stateComponents[0],
+        zoneComponents[0]
+      );
+      return state?.name ?? "";
+    }
+
+    // Handles the {CountryCode:CountryCode-RegionCode} format
+    if (stateComponents.length == 2) {
+      const state = State.getStateByCodeAndCountry(
+        stateComponents[1],
+        zoneComponents[0]
+      );
+      return state?.name ?? "";
+    }
+  }
+
+  return "";
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@react-native-async-storage/async-storage": "^1.18.2",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
+    "country-state-city": "^3.1.4",
     "react": "18.2.0",
     "react-native": "0.71.10",
     "react-native-safe-area-context": "^4.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,6 +1732,11 @@ cosmiconfig@^5.0.5, cosmiconfig@^5.1.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
+country-state-city@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/country-state-city/-/country-state-city-3.1.4.tgz#7f0b616b3b0b206d357d44c50d7fb8b4a73b66c9"
+  integrity sha512-gULjY6rojfdTbgBoPXYbcnmS0SSFzRJl+/jgS/IIxraI7l4YVbT/Jb53OFujJwrQP4d19YC7yWIDHyxtMxgHVQ==
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"


### PR DESCRIPTION
fixes #19 

This PR does two things:

- Updates the UI to match the new designs
- Adds a new dependency called `country-state-city` to be able to get the zone name from the code the API returns.

# Discussion

I think we can get the zone name by quering the some [WC APIs](http://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-countries) but I think this module already hit enough APIs so I opted to query them locally. 

# Screenshots

iOS | Android
---- | ----
<img width="436" alt="ios" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/cd848481-585d-427a-81c3-0ad321a44069"> | <img width="417" alt="android" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/1c282e58-7676-4169-ab53-731743edef42">
