### PR TITLE
Disable country/state name lookup

### DIFF
--- a/Utils/Country.tsx
+++ b/Utils/Country.tsx
@@ -1,4 +1,4 @@
-import { Country, State } from "country-state-city";
+// import { csc } from "country-state-city";
 
 /*
  * Returns the zone name for a country or region.
@@ -9,35 +9,36 @@ import { Country, State } from "country-state-city";
  * - {CountryCode:CountryCode-RegionCode}
  */
 export function getZoneName(countryOrRegion: string) {
-  const zoneComponents = countryOrRegion.split(":");
+  return countryOrRegion;
+  // const zoneComponents = countryOrRegion.split(":");
 
-  // Handles the {CountryCode} format
-  if (zoneComponents.length == 1) {
-    const country = Country.getCountryByCode(zoneComponents[0]);
-    return country?.name ?? "";
-  }
+  // // Handles the {CountryCode} format
+  // if (zoneComponents.length == 1) {
+  //   const country = ICountry.getCountryById(zoneComponents[0]);
+  //   return country?.name ?? "";
+  // }
 
-  if (zoneComponents.length == 2) {
-    const stateComponents = zoneComponents[1].split("-");
+  // if (zoneComponents.length == 2) {
+  //   const stateComponents = zoneComponents[1].split("-");
 
-    // Handles de {CountryCode:RegionCode} format
-    if (stateComponents.length == 1) {
-      const state = State.getStateByCodeAndCountry(
-        stateComponents[0],
-        zoneComponents[0]
-      );
-      return state?.name ?? "";
-    }
+  //   // Handles de {CountryCode:RegionCode} format
+  //   if (stateComponents.length == 1) {
+  //     const state = State.getStateByCodeAndCountry(
+  //       stateComponents[0],
+  //       zoneComponents[0]
+  //     );
+  //     return state?.name ?? "";
+  //   }
 
-    // Handles the {CountryCode:CountryCode-RegionCode} format
-    if (stateComponents.length == 2) {
-      const state = State.getStateByCodeAndCountry(
-        stateComponents[1],
-        zoneComponents[0]
-      );
-      return state?.name ?? "";
-    }
-  }
+  //   // Handles the {CountryCode:CountryCode-RegionCode} format
+  //   if (stateComponents.length == 2) {
+  //     const state = State.getStateByCodeAndCountry(
+  //       stateComponents[1],
+  //       zoneComponents[0]
+  //     );
+  //     return state?.name ?? "";
+  //   }
+  // }
 
-  return "";
+  // return "";
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@react-native-async-storage/async-storage": "^1.18.2",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
-    "country-state-city": "^3.1.4",
     "react": "18.2.0",
     "react-native": "0.71.10",
     "react-native-safe-area-context": "^4.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,11 +1732,6 @@ cosmiconfig@^5.0.5, cosmiconfig@^5.1.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-country-state-city@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/country-state-city/-/country-state-city-3.1.4.tgz#7f0b616b3b0b206d357d44c50d7fb8b4a73b66c9"
-  integrity sha512-gULjY6rojfdTbgBoPXYbcnmS0SSFzRJl+/jgS/IIxraI7l4YVbT/Jb53OFujJwrQP4d19YC7yWIDHyxtMxgHVQ==
-
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"


### PR DESCRIPTION
# Why

Today, after #44 was merged, I started noticing an error when loading the shared app in the iOS simulator.

Apparently, the library I choose for doing the country/state name lookup has problems with react native because it is too big.

- https://github.com/harpreetkhalsagtbit/country-state-city/issues/18

In this PR I'm disabling the name lookup to re-enable development until I find a correct solution.

# Sreenshots

<img width="432" alt="Screenshot 2023-06-29 at 12 56 43 AM" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/9752b99d-fc62-490f-a71d-44e3500f7354">
