### PR TITLE
fix: do not crash on Android activity re-enter

### DIFF
--- a/libraries/android/library/src/main/kotlin/ReactActivity.kt
+++ b/libraries/android/library/src/main/kotlin/ReactActivity.kt
@@ -3,6 +3,7 @@ package com.woocommerce.shared.library
 import android.app.Activity
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.PackageList
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactPackage
@@ -39,6 +40,7 @@ class ReactActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
             .addPackages(packages)
             .setUseDeveloperSupport(BuildConfig.DEBUG)
             .setInitialLifecycleState(LifecycleState.RESUMED)
+            .setJavaScriptExecutorFactory(HermesExecutorFactory())
             .build()
         // The string here (e.g. "MyReactNativeApp") has to match
         // the string in AppRegistry.registerComponent() in index.ts


### PR DESCRIPTION
Closes: #39 

### Description

This PR fixes the crash, which occured on Android only in the following scenario:
- run `ReactActvity`
- close it 
- run `ReactActivity` again.

I've followed [the recommendation](https://github.com/facebook/react-native/issues/36048#issuecomment-1426147936) from the React Native maintainer and added missing configuration to `ReactInstanceManager`