### PR TITLE
Add support to Application Passwords

### DIFF
--- a/API/APIs.tsx
+++ b/API/APIs.tsx
@@ -1,4 +1,9 @@
-import { Dependency, readDependency } from "../Storage/AppDependencies";
+import {
+  getApiToken,
+  getAppPassword,
+  getBlogId,
+  getSiteUrl,
+} from "../Storage/InMemoryDependencies";
 import { jetpackFetch } from "./JetpackAPI";
 import { restFetch } from "./RestAPI";
 
@@ -35,14 +40,21 @@ export class APIError extends Error {
  * It can use the `JetpackAPI` or the `RestAPI` depending on what credentials are available.
  */
 export async function apiFetch(apiVersion: WPComAPIVersion, path: string) {
-  const blogId = (await readDependency(Dependency.blogId)) ?? "";
-  const apiToken = (await readDependency(Dependency.apiToken)) ?? "";
+  const blogId = getBlogId() ?? "";
+  const apiToken = getApiToken() ?? "";
 
   if (blogId.length > 0 && apiToken.length > 0) {
     return jetpackFetch(apiVersion, path, blogId, apiToken);
   }
 
-  return restFetch(apiVersion, path);
+  const siteUrl = getSiteUrl() ?? "";
+  const appPassword = getAppPassword() ?? "";
+
+  if (siteUrl.length > 0 && appPassword.length > 0) {
+    return restFetch(apiVersion, path, siteUrl, appPassword);
+  }
+
+  throw Error("API credentials not found");
 }
 
 /*

--- a/API/APIs.tsx
+++ b/API/APIs.tsx
@@ -1,3 +1,7 @@
+import { Dependency, readDependency } from "../Storage/AppDependencies";
+import { jetpackFetch } from "./JetpackAPI";
+import { restFetch } from "./RestAPI";
+
 /*
  * WPCom API versions definitions
  */
@@ -24,4 +28,27 @@ export class APIError extends Error {
     this.statusCode = statusCode;
     this.json = json;
   }
+}
+
+/*
+ * Utility function to create a an API request.
+ * It can use the `JetpackAPI` or the `RestAPI` depending on what credentials are available.
+ */
+export async function apiFetch(apiVersion: WPComAPIVersion, path: string) {
+  const blogId = (await readDependency(Dependency.blogId)) ?? "";
+  const apiToken = (await readDependency(Dependency.apiToken)) ?? "";
+
+  if (blogId.length > 0 && apiToken.length > 0) {
+    return jetpackFetch(apiVersion, path, blogId, apiToken);
+  }
+
+  return restFetch(apiVersion, path);
+}
+
+/*
+ * Utility function to flatten the `data` object from a json.
+ * We need this because the `JetpackAPI` returns json objects inside a `data` object.
+ */
+export function normalizeJSON(json: any) {
+  return json.data ?? json;
 }

--- a/API/JetpackAPI.tsx
+++ b/API/JetpackAPI.tsx
@@ -1,14 +1,14 @@
-import { Dependency, readDependency } from "../Storage/AppDependencies";
 import { WPComAPIVersion } from "./APIs";
 
 /*
  * Utility function to create a WPCom request using the `jetpack-blogs` tunnel.
- * Fetches the blog id and the auth token from local storage.
- *
  */
-export async function jetpackFetch(apiVersion: WPComAPIVersion, path: string) {
-  const blogId = await readDependency(Dependency.blogId);
-  const apiToken = await readDependency(Dependency.apiToken);
+export async function jetpackFetch(
+  apiVersion: WPComAPIVersion,
+  path: string,
+  blogId: string,
+  apiToken: string
+) {
   const url = `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/${blogId}/rest-api/?path=/${apiVersion}/${path}`;
   console.log(`-- About to fetch: ${url}`); // We can delete this but seems handy for the time being to seee what requests are being fired.
 

--- a/API/RestAPI.tsx
+++ b/API/RestAPI.tsx
@@ -3,10 +3,13 @@ import { WPComAPIVersion } from "./APIs";
 /*
  * Utility function to create a rest request using hitting the site url directly.
  */
-export async function restFetch(apiVersion: WPComAPIVersion, path: string) {
-  const siteAddress = "https://blushing-panther.jurassic.ninja";
-  const appPassword = "ZGVtbzpyOGc0IDVOb1kga1d0MSBvNzdaIFJoODkgM3ZyTw==";
-  const url = `${siteAddress}/wp-json/${apiVersion}/${path}`;
+export async function restFetch(
+  apiVersion: WPComAPIVersion,
+  path: string,
+  siteUrl: string,
+  appPassword: string
+) {
+  const url = `${siteUrl}/wp-json/${apiVersion}/${path}`;
   console.log(`-- About to fetch: ${url}`); // We can delete this but seems handy for the time being to seee what requests are being fired.
 
   return fetch(url, {

--- a/API/RestAPI.tsx
+++ b/API/RestAPI.tsx
@@ -1,0 +1,17 @@
+import { WPComAPIVersion } from "./APIs";
+
+/*
+ * Utility function to create a rest request using hitting the site url directly.
+ */
+export async function restFetch(apiVersion: WPComAPIVersion, path: string) {
+  const siteAddress = "https://blushing-panther.jurassic.ninja";
+  const appPassword = "ZGVtbzpyOGc0IDVOb1kga1d0MSBvNzdaIFJoODkgM3ZyTw==";
+  const url = `${siteAddress}/wp-json/${apiVersion}/${path}`;
+  console.log(`-- About to fetch: ${url}`); // We can delete this but seems handy for the time being to seee what requests are being fired.
+
+  return fetch(url, {
+    headers: {
+      Authorization: `Basic ${appPassword}`,
+    },
+  });
+}

--- a/API/ShippingZoneAPI.tsx
+++ b/API/ShippingZoneAPI.tsx
@@ -1,6 +1,5 @@
 import { getZoneName } from "../Utils/Country";
-import { APIError, WPComAPIVersion } from "./APIs";
-import { jetpackFetch } from "./JetpackAPI";
+import { APIError, WPComAPIVersion, apiFetch, normalizeJSON } from "./APIs";
 
 /*
  * ShippingZone API defition
@@ -37,7 +36,7 @@ export type ShippingZoneMethod = {
 export async function fetchShippingZones() {
   try {
     const path = "shipping/zones";
-    const response = await jetpackFetch(WPComAPIVersion.wcV3, path);
+    const response = await apiFetch(WPComAPIVersion.wcV3, path);
     const json = await response.json();
 
     if (!response.ok) {
@@ -45,7 +44,7 @@ export async function fetchShippingZones() {
     }
 
     const zones: ShippingZone[] = await Promise.all(
-      json.data.map(async (obj) => {
+      normalizeJSON(json).map(async (obj) => {
         return {
           id: obj.id,
           title: obj.name,
@@ -67,14 +66,14 @@ export async function fetchShippingZones() {
 export async function fetchShippingZoneLocations(zoneID: number) {
   try {
     let path = `shipping/zones/${zoneID}/locations`;
-    const response = await jetpackFetch(WPComAPIVersion.wcV3, path);
+    const response = await apiFetch(WPComAPIVersion.wcV3, path);
     const json = await response.json();
 
     if (!response.ok) {
       throw new APIError(path, response.status, json);
     }
 
-    const locations: ShippingZoneLocation[] = json.data.map((obj) => {
+    const locations: ShippingZoneLocation[] = normalizeJSON(json).map((obj) => {
       return {
         code: obj.code,
         name: getZoneName(obj.code),
@@ -94,14 +93,14 @@ export async function fetchShippingZoneLocations(zoneID: number) {
 export async function fetchShippingZoneMethods(zoneID: number) {
   try {
     let path = `shipping/zones/${zoneID}/methods`;
-    const response = await jetpackFetch(WPComAPIVersion.wcV3, path);
+    const response = await apiFetch(WPComAPIVersion.wcV3, path);
     const json = await response.json();
 
     if (!response.ok) {
       throw new APIError(path, response.status, json);
     }
 
-    const methods: ShippingZoneMethod[] = json.data.map((obj) => {
+    const methods: ShippingZoneMethod[] = normalizeJSON(json).map((obj) => {
       return {
         id: obj.method_id,
         title: obj.method_title,

--- a/Storage/InMemoryDependencies.tsx
+++ b/Storage/InMemoryDependencies.tsx
@@ -1,0 +1,41 @@
+/*
+ * Functions to store and read values from memory.
+ * Useful to not store values on disk for security reasons
+ */
+
+let apiToken: string | undefined = undefined;
+let blogId: string | undefined = undefined;
+let siteUrl: string | undefined = undefined;
+let appPassword: string | undefined = undefined;
+
+export function setApiToken(value: string) {
+  apiToken = value;
+}
+
+export function getApiToken() {
+  return apiToken;
+}
+
+export function setBlogId(value: string) {
+  blogId = value;
+}
+
+export function getBlogId() {
+  return blogId;
+}
+
+export function setSiteUrl(value: string) {
+  siteUrl = value;
+}
+
+export function getSiteUrl() {
+  return siteUrl;
+}
+
+export function setAppPassword(value: string) {
+  appPassword = value;
+}
+
+export function getAppPassword() {
+  return appPassword;
+}

--- a/Storage/StoredDependencies.tsx
+++ b/Storage/StoredDependencies.tsx
@@ -4,8 +4,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
  * Depenencies Key definitions.
  */
 export enum Dependency {
-  apiToken = "api-token",
-  blogId = "blog-id",
+  _none = "", // Fill with values when needed
 }
 
 /*

--- a/index.tsx
+++ b/index.tsx
@@ -5,7 +5,12 @@ import AddShippingZone from "./AddShippingZone";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { NavigationRoutes } from "./Navigation/NavigationRoutes";
-import { Dependency, storeDependency } from "./Storage/AppDependencies";
+import {
+  setApiToken,
+  setAppPassword,
+  setBlogId,
+  setSiteUrl,
+} from "./Storage/InMemoryDependencies";
 
 const Stack = createNativeStackNavigator();
 
@@ -17,13 +22,15 @@ const NavigationStack = (props) => {
 
   /*
    * Store properties passed from the native app.
-   * Currenty only `blogID` and `token`
+   * Currenty only `blogID`, `token`, `siteUrl`, and `appPassword`
    */
-  const storeDependencies = async () => {
+  const storeDependencies = () => {
     setSavingDependencies(true);
 
-    await storeDependency(Dependency.apiToken, props["token"]);
-    await storeDependency(Dependency.blogId, props["blogId"]);
+    setBlogId(props["blogId"]);
+    setApiToken(props["token"]);
+    setSiteUrl(props["siteUrl"]);
+    setAppPassword(props["appPassword"]);
 
     setSavingDependencies(false);
   };

--- a/libraries/android/library/src/main/kotlin/ReactActivity.kt
+++ b/libraries/android/library/src/main/kotlin/ReactActivity.kt
@@ -18,6 +18,8 @@ class ReactActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
     companion object{
         const val PROPERTY_BLOG_ID = "blogId"
         const val PROPERTY_TOKEN = "token"
+        const val PROPERTY_SITE_URL = "siteUrl"
+        const val PROPERTY_APP_PASSWORD = "appPassword"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,9 +46,13 @@ class ReactActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
         // the string in AppRegistry.registerComponent() in index.ts
         val token = intent.getStringExtra(PROPERTY_TOKEN)
         val blogId = intent.getStringExtra(PROPERTY_BLOG_ID)
+        val siteURL = intent.getStringExtra(PROPERTY_SITE_URL)
+        val appPassword = intent.getStringExtra(PROPERTY_APP_PASSWORD)
         val initialProperties = Bundle().apply {
             putString(PROPERTY_TOKEN, token)
             putString(PROPERTY_BLOG_ID, blogId)
+            putString(PROPERTY_SITE_URL, siteURL)
+            putString(PROPERTY_APP_PASSWORD, appPassword)
         }
         reactRootView.startReactApplication(reactInstanceManager, "main", initialProperties)
         setContentView(reactRootView)


### PR DESCRIPTION
close #15 

# Why

This PR adds support to the react app to make requests using application passwords for non-jetpack sites.

# How

- Receive two new injected properties. `siteUrl` and `appPassword`

- Migrated our local storage to in-memory storage as It is not very safe to store auth tokens in the filesystem.

- Added a new `apiFetch` that will decide if we need to use a jetpack fetch or a rest api fetch.

# Screenshots

<img width="396" alt="Screenshot 2023-06-29 at 3 03 23 PM" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/ad80aa46-c666-491b-b139-3894922b6395">

# Testing Steps

- Create a jurassic ninja site
- Inject `siteUrl` and `appPassword` to the react app (ping me if you need these details)
- Run the app and see that everything runs.
 

