### PR TITLE
Add country/state name lookup

### DIFF
--- a/Utils/Country.tsx
+++ b/Utils/Country.tsx
@@ -1,44 +1,41 @@
-// import { csc } from "country-state-city";
+import countries from "./country-states.json";
 
 /*
- * Returns the zone name for a country or region.
- * Returns an empty string for an unknown country, region or format.
+ * Returns the zone name for a country or state.
+ * Returns an empty string for an unknown country or state.
  * Supported formats:
  * - {CountryCode}
- * - {CountryCode:RegionCode}
- * - {CountryCode:CountryCode-RegionCode}
+ * - {CountryCode:StateCode}
  */
 export function getZoneName(countryOrRegion: string) {
+  const zoneComponents = countryOrRegion.split(":");
+
+  // Handles the {CountryCode} format
+  if (zoneComponents.length == 1) {
+    const country = getCountryByCode(zoneComponents[0]);
+    return country.name ?? countryOrRegion;
+  }
+
+  // Handles de {CountryCode:StateCode} format
+  if (zoneComponents.length == 2) {
+    const country = getCountryByCode(zoneComponents[0]);
+    const state = getStateByCode(country, zoneComponents[1]);
+    return state.name ?? countryOrRegion;
+  }
+
   return countryOrRegion;
-  // const zoneComponents = countryOrRegion.split(":");
+}
 
-  // // Handles the {CountryCode} format
-  // if (zoneComponents.length == 1) {
-  //   const country = ICountry.getCountryById(zoneComponents[0]);
-  //   return country?.name ?? "";
-  // }
+/*
+ * Finds a country from the list of countries using a country code.
+ */
+function getCountryByCode(countryCode: string): any {
+  return countries.find((country: any) => country.code === countryCode);
+}
 
-  // if (zoneComponents.length == 2) {
-  //   const stateComponents = zoneComponents[1].split("-");
-
-  //   // Handles de {CountryCode:RegionCode} format
-  //   if (stateComponents.length == 1) {
-  //     const state = State.getStateByCodeAndCountry(
-  //       stateComponents[0],
-  //       zoneComponents[0]
-  //     );
-  //     return state?.name ?? "";
-  //   }
-
-  //   // Handles the {CountryCode:CountryCode-RegionCode} format
-  //   if (stateComponents.length == 2) {
-  //     const state = State.getStateByCodeAndCountry(
-  //       stateComponents[1],
-  //       zoneComponents[0]
-  //     );
-  //     return state?.name ?? "";
-  //   }
-  // }
-
-  // return "";
+/*
+ * Finds a state from the list of states of a country using a state code.
+ */
+function getStateByCode(country: any, stateCode: string): any {
+  return country.states.find((state: any) => state.code === stateCode);
 }

--- a/Utils/country-states.json
+++ b/Utils/country-states.json
@@ -1,0 +1,8981 @@
+[
+  {
+    "code": "AF",
+    "name": "Afghanistan",
+    "states": []
+  },
+  {
+    "code": "AX",
+    "name": "Åland Islands",
+    "states": []
+  },
+  {
+    "code": "AL",
+    "name": "Albania",
+    "states": [
+      {
+        "code": "AL-01",
+        "name": "Berat"
+      },
+      {
+        "code": "AL-09",
+        "name": "Dibër"
+      },
+      {
+        "code": "AL-02",
+        "name": "Durrës"
+      },
+      {
+        "code": "AL-03",
+        "name": "Elbasan"
+      },
+      {
+        "code": "AL-04",
+        "name": "Fier"
+      },
+      {
+        "code": "AL-05",
+        "name": "Gjirokastër"
+      },
+      {
+        "code": "AL-06",
+        "name": "Korçë"
+      },
+      {
+        "code": "AL-07",
+        "name": "Kukës"
+      },
+      {
+        "code": "AL-08",
+        "name": "Lezhë"
+      },
+      {
+        "code": "AL-10",
+        "name": "Shkodër"
+      },
+      {
+        "code": "AL-11",
+        "name": "Tirana"
+      },
+      {
+        "code": "AL-12",
+        "name": "Vlorë"
+      }
+    ]
+  },
+  {
+    "code": "DZ",
+    "name": "Algeria",
+    "states": [
+      {
+        "code": "DZ-01",
+        "name": "Adrar"
+      },
+      {
+        "code": "DZ-02",
+        "name": "Chlef"
+      },
+      {
+        "code": "DZ-03",
+        "name": "Laghouat"
+      },
+      {
+        "code": "DZ-04",
+        "name": "Oum El Bouaghi"
+      },
+      {
+        "code": "DZ-05",
+        "name": "Batna"
+      },
+      {
+        "code": "DZ-06",
+        "name": "Béjaïa"
+      },
+      {
+        "code": "DZ-07",
+        "name": "Biskra"
+      },
+      {
+        "code": "DZ-08",
+        "name": "Béchar"
+      },
+      {
+        "code": "DZ-09",
+        "name": "Blida"
+      },
+      {
+        "code": "DZ-10",
+        "name": "Bouira"
+      },
+      {
+        "code": "DZ-11",
+        "name": "Tamanghasset"
+      },
+      {
+        "code": "DZ-12",
+        "name": "Tébessa"
+      },
+      {
+        "code": "DZ-13",
+        "name": "Tlemcen"
+      },
+      {
+        "code": "DZ-14",
+        "name": "Tiaret"
+      },
+      {
+        "code": "DZ-15",
+        "name": "Tizi Ouzou"
+      },
+      {
+        "code": "DZ-16",
+        "name": "Algiers"
+      },
+      {
+        "code": "DZ-17",
+        "name": "Djelfa"
+      },
+      {
+        "code": "DZ-18",
+        "name": "Jijel"
+      },
+      {
+        "code": "DZ-19",
+        "name": "Sétif"
+      },
+      {
+        "code": "DZ-20",
+        "name": "Saïda"
+      },
+      {
+        "code": "DZ-21",
+        "name": "Skikda"
+      },
+      {
+        "code": "DZ-22",
+        "name": "Sidi Bel Abbès"
+      },
+      {
+        "code": "DZ-23",
+        "name": "Annaba"
+      },
+      {
+        "code": "DZ-24",
+        "name": "Guelma"
+      },
+      {
+        "code": "DZ-25",
+        "name": "Constantine"
+      },
+      {
+        "code": "DZ-26",
+        "name": "Médéa"
+      },
+      {
+        "code": "DZ-27",
+        "name": "Mostaganem"
+      },
+      {
+        "code": "DZ-28",
+        "name": "M’Sila"
+      },
+      {
+        "code": "DZ-29",
+        "name": "Mascara"
+      },
+      {
+        "code": "DZ-30",
+        "name": "Ouargla"
+      },
+      {
+        "code": "DZ-31",
+        "name": "Oran"
+      },
+      {
+        "code": "DZ-32",
+        "name": "El Bayadh"
+      },
+      {
+        "code": "DZ-33",
+        "name": "Illizi"
+      },
+      {
+        "code": "DZ-34",
+        "name": "Bordj Bou Arréridj"
+      },
+      {
+        "code": "DZ-35",
+        "name": "Boumerdès"
+      },
+      {
+        "code": "DZ-36",
+        "name": "El Tarf"
+      },
+      {
+        "code": "DZ-37",
+        "name": "Tindouf"
+      },
+      {
+        "code": "DZ-38",
+        "name": "Tissemsilt"
+      },
+      {
+        "code": "DZ-39",
+        "name": "El Oued"
+      },
+      {
+        "code": "DZ-40",
+        "name": "Khenchela"
+      },
+      {
+        "code": "DZ-41",
+        "name": "Souk Ahras"
+      },
+      {
+        "code": "DZ-42",
+        "name": "Tipasa"
+      },
+      {
+        "code": "DZ-43",
+        "name": "Mila"
+      },
+      {
+        "code": "DZ-44",
+        "name": "Aïn Defla"
+      },
+      {
+        "code": "DZ-45",
+        "name": "Naama"
+      },
+      {
+        "code": "DZ-46",
+        "name": "Aïn Témouchent"
+      },
+      {
+        "code": "DZ-47",
+        "name": "Ghardaïa"
+      },
+      {
+        "code": "DZ-48",
+        "name": "Relizane"
+      }
+    ]
+  },
+  {
+    "code": "AS",
+    "name": "American Samoa",
+    "states": []
+  },
+  {
+    "code": "AD",
+    "name": "Andorra",
+    "states": []
+  },
+  {
+    "code": "AO",
+    "name": "Angola",
+    "states": [
+      {
+        "code": "BGO",
+        "name": "Bengo"
+      },
+      {
+        "code": "BLU",
+        "name": "Benguela"
+      },
+      {
+        "code": "BIE",
+        "name": "Bié"
+      },
+      {
+        "code": "CAB",
+        "name": "Cabinda"
+      },
+      {
+        "code": "CNN",
+        "name": "Cunene"
+      },
+      {
+        "code": "HUA",
+        "name": "Huambo"
+      },
+      {
+        "code": "HUI",
+        "name": "Huíla"
+      },
+      {
+        "code": "CCU",
+        "name": "Kuando Kubango"
+      },
+      {
+        "code": "CNO",
+        "name": "Kwanza-Norte"
+      },
+      {
+        "code": "CUS",
+        "name": "Kwanza-Sul"
+      },
+      {
+        "code": "LUA",
+        "name": "Luanda"
+      },
+      {
+        "code": "LNO",
+        "name": "Lunda-Norte"
+      },
+      {
+        "code": "LSU",
+        "name": "Lunda-Sul"
+      },
+      {
+        "code": "MAL",
+        "name": "Malanje"
+      },
+      {
+        "code": "MOX",
+        "name": "Moxico"
+      },
+      {
+        "code": "NAM",
+        "name": "Namibe"
+      },
+      {
+        "code": "UIG",
+        "name": "Uíge"
+      },
+      {
+        "code": "ZAI",
+        "name": "Zaire"
+      }
+    ]
+  },
+  {
+    "code": "AI",
+    "name": "Anguilla",
+    "states": []
+  },
+  {
+    "code": "AQ",
+    "name": "Antarctica",
+    "states": []
+  },
+  {
+    "code": "AG",
+    "name": "Antigua and Barbuda",
+    "states": []
+  },
+  {
+    "code": "AR",
+    "name": "Argentina",
+    "states": [
+      {
+        "code": "C",
+        "name": "Ciudad Autónoma de Buenos Aires"
+      },
+      {
+        "code": "B",
+        "name": "Buenos Aires"
+      },
+      {
+        "code": "K",
+        "name": "Catamarca"
+      },
+      {
+        "code": "H",
+        "name": "Chaco"
+      },
+      {
+        "code": "U",
+        "name": "Chubut"
+      },
+      {
+        "code": "X",
+        "name": "Córdoba"
+      },
+      {
+        "code": "W",
+        "name": "Corrientes"
+      },
+      {
+        "code": "E",
+        "name": "Entre Ríos"
+      },
+      {
+        "code": "P",
+        "name": "Formosa"
+      },
+      {
+        "code": "Y",
+        "name": "Jujuy"
+      },
+      {
+        "code": "L",
+        "name": "La Pampa"
+      },
+      {
+        "code": "F",
+        "name": "La Rioja"
+      },
+      {
+        "code": "M",
+        "name": "Mendoza"
+      },
+      {
+        "code": "N",
+        "name": "Misiones"
+      },
+      {
+        "code": "Q",
+        "name": "Neuquén"
+      },
+      {
+        "code": "R",
+        "name": "Río Negro"
+      },
+      {
+        "code": "A",
+        "name": "Salta"
+      },
+      {
+        "code": "J",
+        "name": "San Juan"
+      },
+      {
+        "code": "D",
+        "name": "San Luis"
+      },
+      {
+        "code": "Z",
+        "name": "Santa Cruz"
+      },
+      {
+        "code": "S",
+        "name": "Santa Fe"
+      },
+      {
+        "code": "G",
+        "name": "Santiago del Estero"
+      },
+      {
+        "code": "V",
+        "name": "Tierra del Fuego"
+      },
+      {
+        "code": "T",
+        "name": "Tucumán"
+      }
+    ]
+  },
+  {
+    "code": "AM",
+    "name": "Armenia",
+    "states": []
+  },
+  {
+    "code": "AW",
+    "name": "Aruba",
+    "states": []
+  },
+  {
+    "code": "AU",
+    "name": "Australia",
+    "states": [
+      {
+        "code": "ACT",
+        "name": "Australian Capital Territory"
+      },
+      {
+        "code": "NSW",
+        "name": "New South Wales"
+      },
+      {
+        "code": "NT",
+        "name": "Northern Territory"
+      },
+      {
+        "code": "QLD",
+        "name": "Queensland"
+      },
+      {
+        "code": "SA",
+        "name": "South Australia"
+      },
+      {
+        "code": "TAS",
+        "name": "Tasmania"
+      },
+      {
+        "code": "VIC",
+        "name": "Victoria"
+      },
+      {
+        "code": "WA",
+        "name": "Western Australia"
+      }
+    ]
+  },
+  {
+    "code": "AT",
+    "name": "Austria",
+    "states": []
+  },
+  {
+    "code": "AZ",
+    "name": "Azerbaijan",
+    "states": []
+  },
+  {
+    "code": "BS",
+    "name": "Bahamas",
+    "states": []
+  },
+  {
+    "code": "BH",
+    "name": "Bahrain",
+    "states": []
+  },
+  {
+    "code": "BD",
+    "name": "Bangladesh",
+    "states": [
+      {
+        "code": "BD-05",
+        "name": "Bagerhat"
+      },
+      {
+        "code": "BD-01",
+        "name": "Bandarban"
+      },
+      {
+        "code": "BD-02",
+        "name": "Barguna"
+      },
+      {
+        "code": "BD-06",
+        "name": "Barishal"
+      },
+      {
+        "code": "BD-07",
+        "name": "Bhola"
+      },
+      {
+        "code": "BD-03",
+        "name": "Bogura"
+      },
+      {
+        "code": "BD-04",
+        "name": "Brahmanbaria"
+      },
+      {
+        "code": "BD-09",
+        "name": "Chandpur"
+      },
+      {
+        "code": "BD-10",
+        "name": "Chattogram"
+      },
+      {
+        "code": "BD-12",
+        "name": "Chuadanga"
+      },
+      {
+        "code": "BD-11",
+        "name": "Cox's Bazar"
+      },
+      {
+        "code": "BD-08",
+        "name": "Cumilla"
+      },
+      {
+        "code": "BD-13",
+        "name": "Dhaka"
+      },
+      {
+        "code": "BD-14",
+        "name": "Dinajpur"
+      },
+      {
+        "code": "BD-15",
+        "name": "Faridpur "
+      },
+      {
+        "code": "BD-16",
+        "name": "Feni"
+      },
+      {
+        "code": "BD-19",
+        "name": "Gaibandha"
+      },
+      {
+        "code": "BD-18",
+        "name": "Gazipur"
+      },
+      {
+        "code": "BD-17",
+        "name": "Gopalganj"
+      },
+      {
+        "code": "BD-20",
+        "name": "Habiganj"
+      },
+      {
+        "code": "BD-21",
+        "name": "Jamalpur"
+      },
+      {
+        "code": "BD-22",
+        "name": "Jashore"
+      },
+      {
+        "code": "BD-25",
+        "name": "Jhalokati"
+      },
+      {
+        "code": "BD-23",
+        "name": "Jhenaidah"
+      },
+      {
+        "code": "BD-24",
+        "name": "Joypurhat"
+      },
+      {
+        "code": "BD-29",
+        "name": "Khagrachhari"
+      },
+      {
+        "code": "BD-27",
+        "name": "Khulna"
+      },
+      {
+        "code": "BD-26",
+        "name": "Kishoreganj"
+      },
+      {
+        "code": "BD-28",
+        "name": "Kurigram"
+      },
+      {
+        "code": "BD-30",
+        "name": "Kushtia"
+      },
+      {
+        "code": "BD-31",
+        "name": "Lakshmipur"
+      },
+      {
+        "code": "BD-32",
+        "name": "Lalmonirhat"
+      },
+      {
+        "code": "BD-36",
+        "name": "Madaripur"
+      },
+      {
+        "code": "BD-37",
+        "name": "Magura"
+      },
+      {
+        "code": "BD-33",
+        "name": "Manikganj "
+      },
+      {
+        "code": "BD-39",
+        "name": "Meherpur"
+      },
+      {
+        "code": "BD-38",
+        "name": "Moulvibazar"
+      },
+      {
+        "code": "BD-35",
+        "name": "Munshiganj"
+      },
+      {
+        "code": "BD-34",
+        "name": "Mymensingh"
+      },
+      {
+        "code": "BD-48",
+        "name": "Naogaon"
+      },
+      {
+        "code": "BD-43",
+        "name": "Narail"
+      },
+      {
+        "code": "BD-40",
+        "name": "Narayanganj"
+      },
+      {
+        "code": "BD-42",
+        "name": "Narsingdi"
+      },
+      {
+        "code": "BD-44",
+        "name": "Natore"
+      },
+      {
+        "code": "BD-45",
+        "name": "Nawabganj"
+      },
+      {
+        "code": "BD-41",
+        "name": "Netrakona"
+      },
+      {
+        "code": "BD-46",
+        "name": "Nilphamari"
+      },
+      {
+        "code": "BD-47",
+        "name": "Noakhali"
+      },
+      {
+        "code": "BD-49",
+        "name": "Pabna"
+      },
+      {
+        "code": "BD-52",
+        "name": "Panchagarh"
+      },
+      {
+        "code": "BD-51",
+        "name": "Patuakhali"
+      },
+      {
+        "code": "BD-50",
+        "name": "Pirojpur"
+      },
+      {
+        "code": "BD-53",
+        "name": "Rajbari"
+      },
+      {
+        "code": "BD-54",
+        "name": "Rajshahi"
+      },
+      {
+        "code": "BD-56",
+        "name": "Rangamati"
+      },
+      {
+        "code": "BD-55",
+        "name": "Rangpur"
+      },
+      {
+        "code": "BD-58",
+        "name": "Satkhira"
+      },
+      {
+        "code": "BD-62",
+        "name": "Shariatpur"
+      },
+      {
+        "code": "BD-57",
+        "name": "Sherpur"
+      },
+      {
+        "code": "BD-59",
+        "name": "Sirajganj"
+      },
+      {
+        "code": "BD-61",
+        "name": "Sunamganj"
+      },
+      {
+        "code": "BD-60",
+        "name": "Sylhet"
+      },
+      {
+        "code": "BD-63",
+        "name": "Tangail"
+      },
+      {
+        "code": "BD-64",
+        "name": "Thakurgaon"
+      }
+    ]
+  },
+  {
+    "code": "BB",
+    "name": "Barbados",
+    "states": []
+  },
+  {
+    "code": "BY",
+    "name": "Belarus",
+    "states": []
+  },
+  {
+    "code": "PW",
+    "name": "Belau",
+    "states": []
+  },
+  {
+    "code": "BE",
+    "name": "Belgium",
+    "states": []
+  },
+  {
+    "code": "BZ",
+    "name": "Belize",
+    "states": []
+  },
+  {
+    "code": "BJ",
+    "name": "Benin",
+    "states": [
+      {
+        "code": "AL",
+        "name": "Alibori"
+      },
+      {
+        "code": "AK",
+        "name": "Atakora"
+      },
+      {
+        "code": "AQ",
+        "name": "Atlantique"
+      },
+      {
+        "code": "BO",
+        "name": "Borgou"
+      },
+      {
+        "code": "CO",
+        "name": "Collines"
+      },
+      {
+        "code": "KO",
+        "name": "Kouffo"
+      },
+      {
+        "code": "DO",
+        "name": "Donga"
+      },
+      {
+        "code": "LI",
+        "name": "Littoral"
+      },
+      {
+        "code": "MO",
+        "name": "Mono"
+      },
+      {
+        "code": "OU",
+        "name": "Ouémé"
+      },
+      {
+        "code": "PL",
+        "name": "Plateau"
+      },
+      {
+        "code": "ZO",
+        "name": "Zou"
+      }
+    ]
+  },
+  {
+    "code": "BM",
+    "name": "Bermuda",
+    "states": []
+  },
+  {
+    "code": "BT",
+    "name": "Bhutan",
+    "states": []
+  },
+  {
+    "code": "BO",
+    "name": "Bolivia",
+    "states": [
+      {
+        "code": "BO-B",
+        "name": "Beni"
+      },
+      {
+        "code": "BO-H",
+        "name": "Chuquisaca"
+      },
+      {
+        "code": "BO-C",
+        "name": "Cochabamba"
+      },
+      {
+        "code": "BO-L",
+        "name": "La Paz"
+      },
+      {
+        "code": "BO-O",
+        "name": "Oruro"
+      },
+      {
+        "code": "BO-N",
+        "name": "Pando"
+      },
+      {
+        "code": "BO-P",
+        "name": "Potosí"
+      },
+      {
+        "code": "BO-S",
+        "name": "Santa Cruz"
+      },
+      {
+        "code": "BO-T",
+        "name": "Tarija"
+      }
+    ]
+  },
+  {
+    "code": "BQ",
+    "name": "Bonaire, Saint Eustatius and Saba",
+    "states": []
+  },
+  {
+    "code": "BA",
+    "name": "Bosnia and Herzegovina",
+    "states": []
+  },
+  {
+    "code": "BW",
+    "name": "Botswana",
+    "states": []
+  },
+  {
+    "code": "BV",
+    "name": "Bouvet Island",
+    "states": []
+  },
+  {
+    "code": "BR",
+    "name": "Brazil",
+    "states": [
+      {
+        "code": "AC",
+        "name": "Acre"
+      },
+      {
+        "code": "AL",
+        "name": "Alagoas"
+      },
+      {
+        "code": "AP",
+        "name": "Amapá"
+      },
+      {
+        "code": "AM",
+        "name": "Amazonas"
+      },
+      {
+        "code": "BA",
+        "name": "Bahia"
+      },
+      {
+        "code": "CE",
+        "name": "Ceará"
+      },
+      {
+        "code": "DF",
+        "name": "Distrito Federal"
+      },
+      {
+        "code": "ES",
+        "name": "Espírito Santo"
+      },
+      {
+        "code": "GO",
+        "name": "Goiás"
+      },
+      {
+        "code": "MA",
+        "name": "Maranhão"
+      },
+      {
+        "code": "MT",
+        "name": "Mato Grosso"
+      },
+      {
+        "code": "MS",
+        "name": "Mato Grosso do Sul"
+      },
+      {
+        "code": "MG",
+        "name": "Minas Gerais"
+      },
+      {
+        "code": "PA",
+        "name": "Pará"
+      },
+      {
+        "code": "PB",
+        "name": "Paraíba"
+      },
+      {
+        "code": "PR",
+        "name": "Paraná"
+      },
+      {
+        "code": "PE",
+        "name": "Pernambuco"
+      },
+      {
+        "code": "PI",
+        "name": "Piauí"
+      },
+      {
+        "code": "RJ",
+        "name": "Rio de Janeiro"
+      },
+      {
+        "code": "RN",
+        "name": "Rio Grande do Norte"
+      },
+      {
+        "code": "RS",
+        "name": "Rio Grande do Sul"
+      },
+      {
+        "code": "RO",
+        "name": "Rondônia"
+      },
+      {
+        "code": "RR",
+        "name": "Roraima"
+      },
+      {
+        "code": "SC",
+        "name": "Santa Catarina"
+      },
+      {
+        "code": "SP",
+        "name": "São Paulo"
+      },
+      {
+        "code": "SE",
+        "name": "Sergipe"
+      },
+      {
+        "code": "TO",
+        "name": "Tocantins"
+      }
+    ]
+  },
+  {
+    "code": "IO",
+    "name": "British Indian Ocean Territory",
+    "states": []
+  },
+  {
+    "code": "BN",
+    "name": "Brunei",
+    "states": []
+  },
+  {
+    "code": "BG",
+    "name": "Bulgaria",
+    "states": [
+      {
+        "code": "BG-01",
+        "name": "Blagoevgrad"
+      },
+      {
+        "code": "BG-02",
+        "name": "Burgas"
+      },
+      {
+        "code": "BG-08",
+        "name": "Dobrich"
+      },
+      {
+        "code": "BG-07",
+        "name": "Gabrovo"
+      },
+      {
+        "code": "BG-26",
+        "name": "Haskovo"
+      },
+      {
+        "code": "BG-09",
+        "name": "Kardzhali"
+      },
+      {
+        "code": "BG-10",
+        "name": "Kyustendil"
+      },
+      {
+        "code": "BG-11",
+        "name": "Lovech"
+      },
+      {
+        "code": "BG-12",
+        "name": "Montana"
+      },
+      {
+        "code": "BG-13",
+        "name": "Pazardzhik"
+      },
+      {
+        "code": "BG-14",
+        "name": "Pernik"
+      },
+      {
+        "code": "BG-15",
+        "name": "Pleven"
+      },
+      {
+        "code": "BG-16",
+        "name": "Plovdiv"
+      },
+      {
+        "code": "BG-17",
+        "name": "Razgrad"
+      },
+      {
+        "code": "BG-18",
+        "name": "Ruse"
+      },
+      {
+        "code": "BG-27",
+        "name": "Shumen"
+      },
+      {
+        "code": "BG-19",
+        "name": "Silistra"
+      },
+      {
+        "code": "BG-20",
+        "name": "Sliven"
+      },
+      {
+        "code": "BG-21",
+        "name": "Smolyan"
+      },
+      {
+        "code": "BG-23",
+        "name": "Sofia District"
+      },
+      {
+        "code": "BG-22",
+        "name": "Sofia"
+      },
+      {
+        "code": "BG-24",
+        "name": "Stara Zagora"
+      },
+      {
+        "code": "BG-25",
+        "name": "Targovishte"
+      },
+      {
+        "code": "BG-03",
+        "name": "Varna"
+      },
+      {
+        "code": "BG-04",
+        "name": "Veliko Tarnovo"
+      },
+      {
+        "code": "BG-05",
+        "name": "Vidin"
+      },
+      {
+        "code": "BG-06",
+        "name": "Vratsa"
+      },
+      {
+        "code": "BG-28",
+        "name": "Yambol"
+      }
+    ]
+  },
+  {
+    "code": "BF",
+    "name": "Burkina Faso",
+    "states": []
+  },
+  {
+    "code": "BI",
+    "name": "Burundi",
+    "states": []
+  },
+  {
+    "code": "KH",
+    "name": "Cambodia",
+    "states": []
+  },
+  {
+    "code": "CM",
+    "name": "Cameroon",
+    "states": []
+  },
+  {
+    "code": "CA",
+    "name": "Canada",
+    "states": [
+      {
+        "code": "AB",
+        "name": "Alberta"
+      },
+      {
+        "code": "BC",
+        "name": "British Columbia"
+      },
+      {
+        "code": "MB",
+        "name": "Manitoba"
+      },
+      {
+        "code": "NB",
+        "name": "New Brunswick"
+      },
+      {
+        "code": "NL",
+        "name": "Newfoundland and Labrador"
+      },
+      {
+        "code": "NT",
+        "name": "Northwest Territories"
+      },
+      {
+        "code": "NS",
+        "name": "Nova Scotia"
+      },
+      {
+        "code": "NU",
+        "name": "Nunavut"
+      },
+      {
+        "code": "ON",
+        "name": "Ontario"
+      },
+      {
+        "code": "PE",
+        "name": "Prince Edward Island"
+      },
+      {
+        "code": "QC",
+        "name": "Quebec"
+      },
+      {
+        "code": "SK",
+        "name": "Saskatchewan"
+      },
+      {
+        "code": "YT",
+        "name": "Yukon Territory"
+      }
+    ]
+  },
+  {
+    "code": "CV",
+    "name": "Cape Verde",
+    "states": []
+  },
+  {
+    "code": "KY",
+    "name": "Cayman Islands",
+    "states": []
+  },
+  {
+    "code": "CF",
+    "name": "Central African Republic",
+    "states": []
+  },
+  {
+    "code": "TD",
+    "name": "Chad",
+    "states": []
+  },
+  {
+    "code": "CL",
+    "name": "Chile",
+    "states": [
+      {
+        "code": "CL-AI",
+        "name": "Aisén del General Carlos Ibañez del Campo"
+      },
+      {
+        "code": "CL-AN",
+        "name": "Antofagasta"
+      },
+      {
+        "code": "CL-AP",
+        "name": "Arica y Parinacota"
+      },
+      {
+        "code": "CL-AR",
+        "name": "La Araucanía"
+      },
+      {
+        "code": "CL-AT",
+        "name": "Atacama"
+      },
+      {
+        "code": "CL-BI",
+        "name": "Biobío"
+      },
+      {
+        "code": "CL-CO",
+        "name": "Coquimbo"
+      },
+      {
+        "code": "CL-LI",
+        "name": "Libertador General Bernardo O'Higgins"
+      },
+      {
+        "code": "CL-LL",
+        "name": "Los Lagos"
+      },
+      {
+        "code": "CL-LR",
+        "name": "Los Ríos"
+      },
+      {
+        "code": "CL-MA",
+        "name": "Magallanes"
+      },
+      {
+        "code": "CL-ML",
+        "name": "Maule"
+      },
+      {
+        "code": "CL-NB",
+        "name": "Ñuble"
+      },
+      {
+        "code": "CL-RM",
+        "name": "Región Metropolitana de Santiago"
+      },
+      {
+        "code": "CL-TA",
+        "name": "Tarapacá"
+      },
+      {
+        "code": "CL-VS",
+        "name": "Valparaíso"
+      }
+    ]
+  },
+  {
+    "code": "CN",
+    "name": "China",
+    "states": [
+      {
+        "code": "CN1",
+        "name": "Yunnan / 云南"
+      },
+      {
+        "code": "CN2",
+        "name": "Beijing / 北京"
+      },
+      {
+        "code": "CN3",
+        "name": "Tianjin / 天津"
+      },
+      {
+        "code": "CN4",
+        "name": "Hebei / 河北"
+      },
+      {
+        "code": "CN5",
+        "name": "Shanxi / 山西"
+      },
+      {
+        "code": "CN6",
+        "name": "Inner Mongolia / 內蒙古"
+      },
+      {
+        "code": "CN7",
+        "name": "Liaoning / 辽宁"
+      },
+      {
+        "code": "CN8",
+        "name": "Jilin / 吉林"
+      },
+      {
+        "code": "CN9",
+        "name": "Heilongjiang / 黑龙江"
+      },
+      {
+        "code": "CN10",
+        "name": "Shanghai / 上海"
+      },
+      {
+        "code": "CN11",
+        "name": "Jiangsu / 江苏"
+      },
+      {
+        "code": "CN12",
+        "name": "Zhejiang / 浙江"
+      },
+      {
+        "code": "CN13",
+        "name": "Anhui / 安徽"
+      },
+      {
+        "code": "CN14",
+        "name": "Fujian / 福建"
+      },
+      {
+        "code": "CN15",
+        "name": "Jiangxi / 江西"
+      },
+      {
+        "code": "CN16",
+        "name": "Shandong / 山东"
+      },
+      {
+        "code": "CN17",
+        "name": "Henan / 河南"
+      },
+      {
+        "code": "CN18",
+        "name": "Hubei / 湖北"
+      },
+      {
+        "code": "CN19",
+        "name": "Hunan / 湖南"
+      },
+      {
+        "code": "CN20",
+        "name": "Guangdong / 广东"
+      },
+      {
+        "code": "CN21",
+        "name": "Guangxi Zhuang / 广西壮族"
+      },
+      {
+        "code": "CN22",
+        "name": "Hainan / 海南"
+      },
+      {
+        "code": "CN23",
+        "name": "Chongqing / 重庆"
+      },
+      {
+        "code": "CN24",
+        "name": "Sichuan / 四川"
+      },
+      {
+        "code": "CN25",
+        "name": "Guizhou / 贵州"
+      },
+      {
+        "code": "CN26",
+        "name": "Shaanxi / 陕西"
+      },
+      {
+        "code": "CN27",
+        "name": "Gansu / 甘肃"
+      },
+      {
+        "code": "CN28",
+        "name": "Qinghai / 青海"
+      },
+      {
+        "code": "CN29",
+        "name": "Ningxia Hui / 宁夏"
+      },
+      {
+        "code": "CN30",
+        "name": "Macao / 澳门"
+      },
+      {
+        "code": "CN31",
+        "name": "Tibet / 西藏"
+      },
+      {
+        "code": "CN32",
+        "name": "Xinjiang / 新疆"
+      }
+    ]
+  },
+  {
+    "code": "CX",
+    "name": "Christmas Island",
+    "states": []
+  },
+  {
+    "code": "CC",
+    "name": "Cocos (Keeling) Islands",
+    "states": []
+  },
+  {
+    "code": "CO",
+    "name": "Colombia",
+    "states": [
+      {
+        "code": "CO-AMA",
+        "name": "Amazonas"
+      },
+      {
+        "code": "CO-ANT",
+        "name": "Antioquia"
+      },
+      {
+        "code": "CO-ARA",
+        "name": "Arauca"
+      },
+      {
+        "code": "CO-ATL",
+        "name": "Atlántico"
+      },
+      {
+        "code": "CO-BOL",
+        "name": "Bolívar"
+      },
+      {
+        "code": "CO-BOY",
+        "name": "Boyacá"
+      },
+      {
+        "code": "CO-CAL",
+        "name": "Caldas"
+      },
+      {
+        "code": "CO-CAQ",
+        "name": "Caquetá"
+      },
+      {
+        "code": "CO-CAS",
+        "name": "Casanare"
+      },
+      {
+        "code": "CO-CAU",
+        "name": "Cauca"
+      },
+      {
+        "code": "CO-CES",
+        "name": "Cesar"
+      },
+      {
+        "code": "CO-CHO",
+        "name": "Chocó"
+      },
+      {
+        "code": "CO-COR",
+        "name": "Córdoba"
+      },
+      {
+        "code": "CO-CUN",
+        "name": "Cundinamarca"
+      },
+      {
+        "code": "CO-DC",
+        "name": "Capital District"
+      },
+      {
+        "code": "CO-GUA",
+        "name": "Guainía"
+      },
+      {
+        "code": "CO-GUV",
+        "name": "Guaviare"
+      },
+      {
+        "code": "CO-HUI",
+        "name": "Huila"
+      },
+      {
+        "code": "CO-LAG",
+        "name": "La Guajira"
+      },
+      {
+        "code": "CO-MAG",
+        "name": "Magdalena"
+      },
+      {
+        "code": "CO-MET",
+        "name": "Meta"
+      },
+      {
+        "code": "CO-NAR",
+        "name": "Nariño"
+      },
+      {
+        "code": "CO-NSA",
+        "name": "Norte de Santander"
+      },
+      {
+        "code": "CO-PUT",
+        "name": "Putumayo"
+      },
+      {
+        "code": "CO-QUI",
+        "name": "Quindío"
+      },
+      {
+        "code": "CO-RIS",
+        "name": "Risaralda"
+      },
+      {
+        "code": "CO-SAN",
+        "name": "Santander"
+      },
+      {
+        "code": "CO-SAP",
+        "name": "San Andrés & Providencia"
+      },
+      {
+        "code": "CO-SUC",
+        "name": "Sucre"
+      },
+      {
+        "code": "CO-TOL",
+        "name": "Tolima"
+      },
+      {
+        "code": "CO-VAC",
+        "name": "Valle del Cauca"
+      },
+      {
+        "code": "CO-VAU",
+        "name": "Vaupés"
+      },
+      {
+        "code": "CO-VID",
+        "name": "Vichada"
+      }
+    ]
+  },
+  {
+    "code": "KM",
+    "name": "Comoros",
+    "states": []
+  },
+  {
+    "code": "CG",
+    "name": "Congo (Brazzaville)",
+    "states": []
+  },
+  {
+    "code": "CD",
+    "name": "Congo (Kinshasa)",
+    "states": []
+  },
+  {
+    "code": "CK",
+    "name": "Cook Islands",
+    "states": []
+  },
+  {
+    "code": "CR",
+    "name": "Costa Rica",
+    "states": [
+      {
+        "code": "CR-A",
+        "name": "Alajuela"
+      },
+      {
+        "code": "CR-C",
+        "name": "Cartago"
+      },
+      {
+        "code": "CR-G",
+        "name": "Guanacaste"
+      },
+      {
+        "code": "CR-H",
+        "name": "Heredia"
+      },
+      {
+        "code": "CR-L",
+        "name": "Limón"
+      },
+      {
+        "code": "CR-P",
+        "name": "Puntarenas"
+      },
+      {
+        "code": "CR-SJ",
+        "name": "San José"
+      }
+    ]
+  },
+  {
+    "code": "HR",
+    "name": "Croatia",
+    "states": []
+  },
+  {
+    "code": "CU",
+    "name": "Cuba",
+    "states": []
+  },
+  {
+    "code": "CW",
+    "name": "Cura&ccedil;ao",
+    "states": []
+  },
+  {
+    "code": "CY",
+    "name": "Cyprus",
+    "states": []
+  },
+  {
+    "code": "CZ",
+    "name": "Czech Republic",
+    "states": []
+  },
+  {
+    "code": "DK",
+    "name": "Denmark",
+    "states": []
+  },
+  {
+    "code": "DJ",
+    "name": "Djibouti",
+    "states": []
+  },
+  {
+    "code": "DM",
+    "name": "Dominica",
+    "states": []
+  },
+  {
+    "code": "DO",
+    "name": "Dominican Republic",
+    "states": [
+      {
+        "code": "DO-01",
+        "name": "Distrito Nacional"
+      },
+      {
+        "code": "DO-02",
+        "name": "Azua"
+      },
+      {
+        "code": "DO-03",
+        "name": "Baoruco"
+      },
+      {
+        "code": "DO-04",
+        "name": "Barahona"
+      },
+      {
+        "code": "DO-33",
+        "name": "Cibao Nordeste"
+      },
+      {
+        "code": "DO-34",
+        "name": "Cibao Noroeste"
+      },
+      {
+        "code": "DO-35",
+        "name": "Cibao Norte"
+      },
+      {
+        "code": "DO-36",
+        "name": "Cibao Sur"
+      },
+      {
+        "code": "DO-05",
+        "name": "Dajabón"
+      },
+      {
+        "code": "DO-06",
+        "name": "Duarte"
+      },
+      {
+        "code": "DO-08",
+        "name": "El Seibo"
+      },
+      {
+        "code": "DO-37",
+        "name": "El Valle"
+      },
+      {
+        "code": "DO-07",
+        "name": "Elías Piña"
+      },
+      {
+        "code": "DO-38",
+        "name": "Enriquillo"
+      },
+      {
+        "code": "DO-09",
+        "name": "Espaillat"
+      },
+      {
+        "code": "DO-30",
+        "name": "Hato Mayor"
+      },
+      {
+        "code": "DO-19",
+        "name": "Hermanas Mirabal"
+      },
+      {
+        "code": "DO-39",
+        "name": "Higüamo"
+      },
+      {
+        "code": "DO-10",
+        "name": "Independencia"
+      },
+      {
+        "code": "DO-11",
+        "name": "La Altagracia"
+      },
+      {
+        "code": "DO-12",
+        "name": "La Romana"
+      },
+      {
+        "code": "DO-13",
+        "name": "La Vega"
+      },
+      {
+        "code": "DO-14",
+        "name": "María Trinidad Sánchez"
+      },
+      {
+        "code": "DO-28",
+        "name": "Monseñor Nouel"
+      },
+      {
+        "code": "DO-15",
+        "name": "Monte Cristi"
+      },
+      {
+        "code": "DO-29",
+        "name": "Monte Plata"
+      },
+      {
+        "code": "DO-40",
+        "name": "Ozama"
+      },
+      {
+        "code": "DO-16",
+        "name": "Pedernales"
+      },
+      {
+        "code": "DO-17",
+        "name": "Peravia"
+      },
+      {
+        "code": "DO-18",
+        "name": "Puerto Plata"
+      },
+      {
+        "code": "DO-20",
+        "name": "Samaná"
+      },
+      {
+        "code": "DO-21",
+        "name": "San Cristóbal"
+      },
+      {
+        "code": "DO-31",
+        "name": "San José de Ocoa"
+      },
+      {
+        "code": "DO-22",
+        "name": "San Juan"
+      },
+      {
+        "code": "DO-23",
+        "name": "San Pedro de Macorís"
+      },
+      {
+        "code": "DO-24",
+        "name": "Sánchez Ramírez"
+      },
+      {
+        "code": "DO-25",
+        "name": "Santiago"
+      },
+      {
+        "code": "DO-26",
+        "name": "Santiago Rodríguez"
+      },
+      {
+        "code": "DO-32",
+        "name": "Santo Domingo"
+      },
+      {
+        "code": "DO-41",
+        "name": "Valdesia"
+      },
+      {
+        "code": "DO-27",
+        "name": "Valverde"
+      },
+      {
+        "code": "DO-42",
+        "name": "Yuma"
+      }
+    ]
+  },
+  {
+    "code": "EC",
+    "name": "Ecuador",
+    "states": [
+      {
+        "code": "EC-A",
+        "name": "Azuay"
+      },
+      {
+        "code": "EC-B",
+        "name": "Bolívar"
+      },
+      {
+        "code": "EC-F",
+        "name": "Cañar"
+      },
+      {
+        "code": "EC-C",
+        "name": "Carchi"
+      },
+      {
+        "code": "EC-H",
+        "name": "Chimborazo"
+      },
+      {
+        "code": "EC-X",
+        "name": "Cotopaxi"
+      },
+      {
+        "code": "EC-O",
+        "name": "El Oro"
+      },
+      {
+        "code": "EC-E",
+        "name": "Esmeraldas"
+      },
+      {
+        "code": "EC-W",
+        "name": "Galápagos"
+      },
+      {
+        "code": "EC-G",
+        "name": "Guayas"
+      },
+      {
+        "code": "EC-I",
+        "name": "Imbabura"
+      },
+      {
+        "code": "EC-L",
+        "name": "Loja"
+      },
+      {
+        "code": "EC-R",
+        "name": "Los Ríos"
+      },
+      {
+        "code": "EC-M",
+        "name": "Manabí"
+      },
+      {
+        "code": "EC-S",
+        "name": "Morona-Santiago"
+      },
+      {
+        "code": "EC-N",
+        "name": "Napo"
+      },
+      {
+        "code": "EC-D",
+        "name": "Orellana"
+      },
+      {
+        "code": "EC-Y",
+        "name": "Pastaza"
+      },
+      {
+        "code": "EC-P",
+        "name": "Pichincha"
+      },
+      {
+        "code": "EC-SE",
+        "name": "Santa Elena"
+      },
+      {
+        "code": "EC-SD",
+        "name": "Santo Domingo de los Tsáchilas"
+      },
+      {
+        "code": "EC-U",
+        "name": "Sucumbíos"
+      },
+      {
+        "code": "EC-T",
+        "name": "Tungurahua"
+      },
+      {
+        "code": "EC-Z",
+        "name": "Zamora-Chinchipe"
+      }
+    ]
+  },
+  {
+    "code": "EG",
+    "name": "Egypt",
+    "states": [
+      {
+        "code": "EGALX",
+        "name": "Alexandria"
+      },
+      {
+        "code": "EGASN",
+        "name": "Aswan"
+      },
+      {
+        "code": "EGAST",
+        "name": "Asyut"
+      },
+      {
+        "code": "EGBA",
+        "name": "Red Sea"
+      },
+      {
+        "code": "EGBH",
+        "name": "Beheira"
+      },
+      {
+        "code": "EGBNS",
+        "name": "Beni Suef"
+      },
+      {
+        "code": "EGC",
+        "name": "Cairo"
+      },
+      {
+        "code": "EGDK",
+        "name": "Dakahlia"
+      },
+      {
+        "code": "EGDT",
+        "name": "Damietta"
+      },
+      {
+        "code": "EGFYM",
+        "name": "Faiyum"
+      },
+      {
+        "code": "EGGH",
+        "name": "Gharbia"
+      },
+      {
+        "code": "EGGZ",
+        "name": "Giza"
+      },
+      {
+        "code": "EGIS",
+        "name": "Ismailia"
+      },
+      {
+        "code": "EGJS",
+        "name": "South Sinai"
+      },
+      {
+        "code": "EGKB",
+        "name": "Qalyubia"
+      },
+      {
+        "code": "EGKFS",
+        "name": "Kafr el-Sheikh"
+      },
+      {
+        "code": "EGKN",
+        "name": "Qena"
+      },
+      {
+        "code": "EGLX",
+        "name": "Luxor"
+      },
+      {
+        "code": "EGMN",
+        "name": "Minya"
+      },
+      {
+        "code": "EGMNF",
+        "name": "Monufia"
+      },
+      {
+        "code": "EGMT",
+        "name": "Matrouh"
+      },
+      {
+        "code": "EGPTS",
+        "name": "Port Said"
+      },
+      {
+        "code": "EGSHG",
+        "name": "Sohag"
+      },
+      {
+        "code": "EGSHR",
+        "name": "Al Sharqia"
+      },
+      {
+        "code": "EGSIN",
+        "name": "North Sinai"
+      },
+      {
+        "code": "EGSUZ",
+        "name": "Suez"
+      },
+      {
+        "code": "EGWAD",
+        "name": "New Valley"
+      }
+    ]
+  },
+  {
+    "code": "SV",
+    "name": "El Salvador",
+    "states": [
+      {
+        "code": "SV-AH",
+        "name": "Ahuachapán"
+      },
+      {
+        "code": "SV-CA",
+        "name": "Cabañas"
+      },
+      {
+        "code": "SV-CH",
+        "name": "Chalatenango"
+      },
+      {
+        "code": "SV-CU",
+        "name": "Cuscatlán"
+      },
+      {
+        "code": "SV-LI",
+        "name": "La Libertad"
+      },
+      {
+        "code": "SV-MO",
+        "name": "Morazán"
+      },
+      {
+        "code": "SV-PA",
+        "name": "La Paz"
+      },
+      {
+        "code": "SV-SA",
+        "name": "Santa Ana"
+      },
+      {
+        "code": "SV-SM",
+        "name": "San Miguel"
+      },
+      {
+        "code": "SV-SO",
+        "name": "Sonsonate"
+      },
+      {
+        "code": "SV-SS",
+        "name": "San Salvador"
+      },
+      {
+        "code": "SV-SV",
+        "name": "San Vicente"
+      },
+      {
+        "code": "SV-UN",
+        "name": "La Unión"
+      },
+      {
+        "code": "SV-US",
+        "name": "Usulután"
+      }
+    ]
+  },
+  {
+    "code": "GQ",
+    "name": "Equatorial Guinea",
+    "states": []
+  },
+  {
+    "code": "ER",
+    "name": "Eritrea",
+    "states": []
+  },
+  {
+    "code": "EE",
+    "name": "Estonia",
+    "states": []
+  },
+  {
+    "code": "SZ",
+    "name": "Eswatini",
+    "states": []
+  },
+  {
+    "code": "ET",
+    "name": "Ethiopia",
+    "states": []
+  },
+  {
+    "code": "FK",
+    "name": "Falkland Islands",
+    "states": []
+  },
+  {
+    "code": "FO",
+    "name": "Faroe Islands",
+    "states": []
+  },
+  {
+    "code": "FJ",
+    "name": "Fiji",
+    "states": []
+  },
+  {
+    "code": "FI",
+    "name": "Finland",
+    "states": []
+  },
+  {
+    "code": "FR",
+    "name": "France",
+    "states": []
+  },
+  {
+    "code": "GF",
+    "name": "French Guiana",
+    "states": []
+  },
+  {
+    "code": "PF",
+    "name": "French Polynesia",
+    "states": []
+  },
+  {
+    "code": "TF",
+    "name": "French Southern Territories",
+    "states": []
+  },
+  {
+    "code": "GA",
+    "name": "Gabon",
+    "states": []
+  },
+  {
+    "code": "GM",
+    "name": "Gambia",
+    "states": []
+  },
+  {
+    "code": "GE",
+    "name": "Georgia",
+    "states": []
+  },
+  {
+    "code": "DE",
+    "name": "Germany",
+    "states": [
+      {
+        "code": "DE-BW",
+        "name": "Baden-Württemberg"
+      },
+      {
+        "code": "DE-BY",
+        "name": "Bavaria"
+      },
+      {
+        "code": "DE-BE",
+        "name": "Berlin"
+      },
+      {
+        "code": "DE-BB",
+        "name": "Brandenburg"
+      },
+      {
+        "code": "DE-HB",
+        "name": "Bremen"
+      },
+      {
+        "code": "DE-HH",
+        "name": "Hamburg"
+      },
+      {
+        "code": "DE-HE",
+        "name": "Hesse"
+      },
+      {
+        "code": "DE-MV",
+        "name": "Mecklenburg-Vorpommern"
+      },
+      {
+        "code": "DE-NI",
+        "name": "Lower Saxony"
+      },
+      {
+        "code": "DE-NW",
+        "name": "North Rhine-Westphalia"
+      },
+      {
+        "code": "DE-RP",
+        "name": "Rhineland-Palatinate"
+      },
+      {
+        "code": "DE-SL",
+        "name": "Saarland"
+      },
+      {
+        "code": "DE-SN",
+        "name": "Saxony"
+      },
+      {
+        "code": "DE-ST",
+        "name": "Saxony-Anhalt"
+      },
+      {
+        "code": "DE-SH",
+        "name": "Schleswig-Holstein"
+      },
+      {
+        "code": "DE-TH",
+        "name": "Thuringia"
+      }
+    ]
+  },
+  {
+    "code": "GH",
+    "name": "Ghana",
+    "states": [
+      {
+        "code": "AF",
+        "name": "Ahafo"
+      },
+      {
+        "code": "AH",
+        "name": "Ashanti"
+      },
+      {
+        "code": "BA",
+        "name": "Brong-Ahafo"
+      },
+      {
+        "code": "BO",
+        "name": "Bono"
+      },
+      {
+        "code": "BE",
+        "name": "Bono East"
+      },
+      {
+        "code": "CP",
+        "name": "Central"
+      },
+      {
+        "code": "EP",
+        "name": "Eastern"
+      },
+      {
+        "code": "AA",
+        "name": "Greater Accra"
+      },
+      {
+        "code": "NE",
+        "name": "North East"
+      },
+      {
+        "code": "NP",
+        "name": "Northern"
+      },
+      {
+        "code": "OT",
+        "name": "Oti"
+      },
+      {
+        "code": "SV",
+        "name": "Savannah"
+      },
+      {
+        "code": "UE",
+        "name": "Upper East"
+      },
+      {
+        "code": "UW",
+        "name": "Upper West"
+      },
+      {
+        "code": "TV",
+        "name": "Volta"
+      },
+      {
+        "code": "WP",
+        "name": "Western"
+      },
+      {
+        "code": "WN",
+        "name": "Western North"
+      }
+    ]
+  },
+  {
+    "code": "GI",
+    "name": "Gibraltar",
+    "states": []
+  },
+  {
+    "code": "GR",
+    "name": "Greece",
+    "states": [
+      {
+        "code": "I",
+        "name": "Attica"
+      },
+      {
+        "code": "A",
+        "name": "East Macedonia and Thrace"
+      },
+      {
+        "code": "B",
+        "name": "Central Macedonia"
+      },
+      {
+        "code": "C",
+        "name": "West Macedonia"
+      },
+      {
+        "code": "D",
+        "name": "Epirus"
+      },
+      {
+        "code": "E",
+        "name": "Thessaly"
+      },
+      {
+        "code": "F",
+        "name": "Ionian Islands"
+      },
+      {
+        "code": "G",
+        "name": "West Greece"
+      },
+      {
+        "code": "H",
+        "name": "Central Greece"
+      },
+      {
+        "code": "J",
+        "name": "Peloponnese"
+      },
+      {
+        "code": "K",
+        "name": "North Aegean"
+      },
+      {
+        "code": "L",
+        "name": "South Aegean"
+      },
+      {
+        "code": "M",
+        "name": "Crete"
+      }
+    ]
+  },
+  {
+    "code": "GL",
+    "name": "Greenland",
+    "states": []
+  },
+  {
+    "code": "GD",
+    "name": "Grenada",
+    "states": []
+  },
+  {
+    "code": "GP",
+    "name": "Guadeloupe",
+    "states": []
+  },
+  {
+    "code": "GU",
+    "name": "Guam",
+    "states": []
+  },
+  {
+    "code": "GT",
+    "name": "Guatemala",
+    "states": [
+      {
+        "code": "GT-AV",
+        "name": "Alta Verapaz"
+      },
+      {
+        "code": "GT-BV",
+        "name": "Baja Verapaz"
+      },
+      {
+        "code": "GT-CM",
+        "name": "Chimaltenango"
+      },
+      {
+        "code": "GT-CQ",
+        "name": "Chiquimula"
+      },
+      {
+        "code": "GT-PR",
+        "name": "El Progreso"
+      },
+      {
+        "code": "GT-ES",
+        "name": "Escuintla"
+      },
+      {
+        "code": "GT-GU",
+        "name": "Guatemala"
+      },
+      {
+        "code": "GT-HU",
+        "name": "Huehuetenango"
+      },
+      {
+        "code": "GT-IZ",
+        "name": "Izabal"
+      },
+      {
+        "code": "GT-JA",
+        "name": "Jalapa"
+      },
+      {
+        "code": "GT-JU",
+        "name": "Jutiapa"
+      },
+      {
+        "code": "GT-PE",
+        "name": "Petén"
+      },
+      {
+        "code": "GT-QZ",
+        "name": "Quetzaltenango"
+      },
+      {
+        "code": "GT-QC",
+        "name": "Quiché"
+      },
+      {
+        "code": "GT-RE",
+        "name": "Retalhuleu"
+      },
+      {
+        "code": "GT-SA",
+        "name": "Sacatepéquez"
+      },
+      {
+        "code": "GT-SM",
+        "name": "San Marcos"
+      },
+      {
+        "code": "GT-SR",
+        "name": "Santa Rosa"
+      },
+      {
+        "code": "GT-SO",
+        "name": "Sololá"
+      },
+      {
+        "code": "GT-SU",
+        "name": "Suchitepéquez"
+      },
+      {
+        "code": "GT-TO",
+        "name": "Totonicapán"
+      },
+      {
+        "code": "GT-ZA",
+        "name": "Zacapa"
+      }
+    ]
+  },
+  {
+    "code": "GG",
+    "name": "Guernsey",
+    "states": []
+  },
+  {
+    "code": "GN",
+    "name": "Guinea",
+    "states": []
+  },
+  {
+    "code": "GW",
+    "name": "Guinea-Bissau",
+    "states": []
+  },
+  {
+    "code": "GY",
+    "name": "Guyana",
+    "states": []
+  },
+  {
+    "code": "HT",
+    "name": "Haiti",
+    "states": []
+  },
+  {
+    "code": "HM",
+    "name": "Heard Island and McDonald Islands",
+    "states": []
+  },
+  {
+    "code": "HN",
+    "name": "Honduras",
+    "states": [
+      {
+        "code": "HN-AT",
+        "name": "Atlántida"
+      },
+      {
+        "code": "HN-IB",
+        "name": "Bay Islands"
+      },
+      {
+        "code": "HN-CH",
+        "name": "Choluteca"
+      },
+      {
+        "code": "HN-CL",
+        "name": "Colón"
+      },
+      {
+        "code": "HN-CM",
+        "name": "Comayagua"
+      },
+      {
+        "code": "HN-CP",
+        "name": "Copán"
+      },
+      {
+        "code": "HN-CR",
+        "name": "Cortés"
+      },
+      {
+        "code": "HN-EP",
+        "name": "El Paraíso"
+      },
+      {
+        "code": "HN-FM",
+        "name": "Francisco Morazán"
+      },
+      {
+        "code": "HN-GD",
+        "name": "Gracias a Dios"
+      },
+      {
+        "code": "HN-IN",
+        "name": "Intibucá"
+      },
+      {
+        "code": "HN-LE",
+        "name": "Lempira"
+      },
+      {
+        "code": "HN-LP",
+        "name": "La Paz"
+      },
+      {
+        "code": "HN-OC",
+        "name": "Ocotepeque"
+      },
+      {
+        "code": "HN-OL",
+        "name": "Olancho"
+      },
+      {
+        "code": "HN-SB",
+        "name": "Santa Bárbara"
+      },
+      {
+        "code": "HN-VA",
+        "name": "Valle"
+      },
+      {
+        "code": "HN-YO",
+        "name": "Yoro"
+      }
+    ]
+  },
+  {
+    "code": "HK",
+    "name": "Hong Kong",
+    "states": [
+      {
+        "code": "HONG KONG",
+        "name": "Hong Kong Island"
+      },
+      {
+        "code": "KOWLOON",
+        "name": "Kowloon"
+      },
+      {
+        "code": "NEW TERRITORIES",
+        "name": "New Territories"
+      }
+    ]
+  },
+  {
+    "code": "HU",
+    "name": "Hungary",
+    "states": [
+      {
+        "code": "BK",
+        "name": "Bács-Kiskun"
+      },
+      {
+        "code": "BE",
+        "name": "Békés"
+      },
+      {
+        "code": "BA",
+        "name": "Baranya"
+      },
+      {
+        "code": "BZ",
+        "name": "Borsod-Abaúj-Zemplén"
+      },
+      {
+        "code": "BU",
+        "name": "Budapest"
+      },
+      {
+        "code": "CS",
+        "name": "Csongrád-Csanád"
+      },
+      {
+        "code": "FE",
+        "name": "Fejér"
+      },
+      {
+        "code": "GS",
+        "name": "Győr-Moson-Sopron"
+      },
+      {
+        "code": "HB",
+        "name": "Hajdú-Bihar"
+      },
+      {
+        "code": "HE",
+        "name": "Heves"
+      },
+      {
+        "code": "JN",
+        "name": "Jász-Nagykun-Szolnok"
+      },
+      {
+        "code": "KE",
+        "name": "Komárom-Esztergom"
+      },
+      {
+        "code": "NO",
+        "name": "Nógrád"
+      },
+      {
+        "code": "PE",
+        "name": "Pest"
+      },
+      {
+        "code": "SO",
+        "name": "Somogy"
+      },
+      {
+        "code": "SZ",
+        "name": "Szabolcs-Szatmár-Bereg"
+      },
+      {
+        "code": "TO",
+        "name": "Tolna"
+      },
+      {
+        "code": "VA",
+        "name": "Vas"
+      },
+      {
+        "code": "VE",
+        "name": "Veszprém"
+      },
+      {
+        "code": "ZA",
+        "name": "Zala"
+      }
+    ]
+  },
+  {
+    "code": "IS",
+    "name": "Iceland",
+    "states": []
+  },
+  {
+    "code": "IN",
+    "name": "India",
+    "states": [
+      {
+        "code": "AP",
+        "name": "Andhra Pradesh"
+      },
+      {
+        "code": "AR",
+        "name": "Arunachal Pradesh"
+      },
+      {
+        "code": "AS",
+        "name": "Assam"
+      },
+      {
+        "code": "BR",
+        "name": "Bihar"
+      },
+      {
+        "code": "CT",
+        "name": "Chhattisgarh"
+      },
+      {
+        "code": "GA",
+        "name": "Goa"
+      },
+      {
+        "code": "GJ",
+        "name": "Gujarat"
+      },
+      {
+        "code": "HR",
+        "name": "Haryana"
+      },
+      {
+        "code": "HP",
+        "name": "Himachal Pradesh"
+      },
+      {
+        "code": "JK",
+        "name": "Jammu and Kashmir"
+      },
+      {
+        "code": "JH",
+        "name": "Jharkhand"
+      },
+      {
+        "code": "KA",
+        "name": "Karnataka"
+      },
+      {
+        "code": "KL",
+        "name": "Kerala"
+      },
+      {
+        "code": "LA",
+        "name": "Ladakh"
+      },
+      {
+        "code": "MP",
+        "name": "Madhya Pradesh"
+      },
+      {
+        "code": "MH",
+        "name": "Maharashtra"
+      },
+      {
+        "code": "MN",
+        "name": "Manipur"
+      },
+      {
+        "code": "ML",
+        "name": "Meghalaya"
+      },
+      {
+        "code": "MZ",
+        "name": "Mizoram"
+      },
+      {
+        "code": "NL",
+        "name": "Nagaland"
+      },
+      {
+        "code": "OR",
+        "name": "Odisha"
+      },
+      {
+        "code": "PB",
+        "name": "Punjab"
+      },
+      {
+        "code": "RJ",
+        "name": "Rajasthan"
+      },
+      {
+        "code": "SK",
+        "name": "Sikkim"
+      },
+      {
+        "code": "TN",
+        "name": "Tamil Nadu"
+      },
+      {
+        "code": "TS",
+        "name": "Telangana"
+      },
+      {
+        "code": "TR",
+        "name": "Tripura"
+      },
+      {
+        "code": "UK",
+        "name": "Uttarakhand"
+      },
+      {
+        "code": "UP",
+        "name": "Uttar Pradesh"
+      },
+      {
+        "code": "WB",
+        "name": "West Bengal"
+      },
+      {
+        "code": "AN",
+        "name": "Andaman and Nicobar Islands"
+      },
+      {
+        "code": "CH",
+        "name": "Chandigarh"
+      },
+      {
+        "code": "DN",
+        "name": "Dadra and Nagar Haveli"
+      },
+      {
+        "code": "DD",
+        "name": "Daman and Diu"
+      },
+      {
+        "code": "DL",
+        "name": "Delhi"
+      },
+      {
+        "code": "LD",
+        "name": "Lakshadeep"
+      },
+      {
+        "code": "PY",
+        "name": "Pondicherry (Puducherry)"
+      }
+    ]
+  },
+  {
+    "code": "ID",
+    "name": "Indonesia",
+    "states": [
+      {
+        "code": "AC",
+        "name": "Daerah Istimewa Aceh"
+      },
+      {
+        "code": "SU",
+        "name": "Sumatera Utara"
+      },
+      {
+        "code": "SB",
+        "name": "Sumatera Barat"
+      },
+      {
+        "code": "RI",
+        "name": "Riau"
+      },
+      {
+        "code": "KR",
+        "name": "Kepulauan Riau"
+      },
+      {
+        "code": "JA",
+        "name": "Jambi"
+      },
+      {
+        "code": "SS",
+        "name": "Sumatera Selatan"
+      },
+      {
+        "code": "BB",
+        "name": "Bangka Belitung"
+      },
+      {
+        "code": "BE",
+        "name": "Bengkulu"
+      },
+      {
+        "code": "LA",
+        "name": "Lampung"
+      },
+      {
+        "code": "JK",
+        "name": "DKI Jakarta"
+      },
+      {
+        "code": "JB",
+        "name": "Jawa Barat"
+      },
+      {
+        "code": "BT",
+        "name": "Banten"
+      },
+      {
+        "code": "JT",
+        "name": "Jawa Tengah"
+      },
+      {
+        "code": "JI",
+        "name": "Jawa Timur"
+      },
+      {
+        "code": "YO",
+        "name": "Daerah Istimewa Yogyakarta"
+      },
+      {
+        "code": "BA",
+        "name": "Bali"
+      },
+      {
+        "code": "NB",
+        "name": "Nusa Tenggara Barat"
+      },
+      {
+        "code": "NT",
+        "name": "Nusa Tenggara Timur"
+      },
+      {
+        "code": "KB",
+        "name": "Kalimantan Barat"
+      },
+      {
+        "code": "KT",
+        "name": "Kalimantan Tengah"
+      },
+      {
+        "code": "KI",
+        "name": "Kalimantan Timur"
+      },
+      {
+        "code": "KS",
+        "name": "Kalimantan Selatan"
+      },
+      {
+        "code": "KU",
+        "name": "Kalimantan Utara"
+      },
+      {
+        "code": "SA",
+        "name": "Sulawesi Utara"
+      },
+      {
+        "code": "ST",
+        "name": "Sulawesi Tengah"
+      },
+      {
+        "code": "SG",
+        "name": "Sulawesi Tenggara"
+      },
+      {
+        "code": "SR",
+        "name": "Sulawesi Barat"
+      },
+      {
+        "code": "SN",
+        "name": "Sulawesi Selatan"
+      },
+      {
+        "code": "GO",
+        "name": "Gorontalo"
+      },
+      {
+        "code": "MA",
+        "name": "Maluku"
+      },
+      {
+        "code": "MU",
+        "name": "Maluku Utara"
+      },
+      {
+        "code": "PA",
+        "name": "Papua"
+      },
+      {
+        "code": "PB",
+        "name": "Papua Barat"
+      }
+    ]
+  },
+  {
+    "code": "IR",
+    "name": "Iran",
+    "states": [
+      {
+        "code": "KHZ",
+        "name": "Khuzestan (خوزستان)"
+      },
+      {
+        "code": "THR",
+        "name": "Tehran (تهران)"
+      },
+      {
+        "code": "ILM",
+        "name": "Ilaam (ایلام)"
+      },
+      {
+        "code": "BHR",
+        "name": "Bushehr (بوشهر)"
+      },
+      {
+        "code": "ADL",
+        "name": "Ardabil (اردبیل)"
+      },
+      {
+        "code": "ESF",
+        "name": "Isfahan (اصفهان)"
+      },
+      {
+        "code": "YZD",
+        "name": "Yazd (یزد)"
+      },
+      {
+        "code": "KRH",
+        "name": "Kermanshah (کرمانشاه)"
+      },
+      {
+        "code": "KRN",
+        "name": "Kerman (کرمان)"
+      },
+      {
+        "code": "HDN",
+        "name": "Hamadan (همدان)"
+      },
+      {
+        "code": "GZN",
+        "name": "Ghazvin (قزوین)"
+      },
+      {
+        "code": "ZJN",
+        "name": "Zanjan (زنجان)"
+      },
+      {
+        "code": "LRS",
+        "name": "Luristan (لرستان)"
+      },
+      {
+        "code": "ABZ",
+        "name": "Alborz (البرز)"
+      },
+      {
+        "code": "EAZ",
+        "name": "East Azarbaijan (آذربایجان شرقی)"
+      },
+      {
+        "code": "WAZ",
+        "name": "West Azarbaijan (آذربایجان غربی)"
+      },
+      {
+        "code": "CHB",
+        "name": "Chaharmahal and Bakhtiari (چهارمحال و بختیاری)"
+      },
+      {
+        "code": "SKH",
+        "name": "South Khorasan (خراسان جنوبی)"
+      },
+      {
+        "code": "RKH",
+        "name": "Razavi Khorasan (خراسان رضوی)"
+      },
+      {
+        "code": "NKH",
+        "name": "North Khorasan (خراسان شمالی)"
+      },
+      {
+        "code": "SMN",
+        "name": "Semnan (سمنان)"
+      },
+      {
+        "code": "FRS",
+        "name": "Fars (فارس)"
+      },
+      {
+        "code": "QHM",
+        "name": "Qom (قم)"
+      },
+      {
+        "code": "KRD",
+        "name": "Kurdistan / کردستان)"
+      },
+      {
+        "code": "KBD",
+        "name": "Kohgiluyeh and BoyerAhmad (کهگیلوییه و بویراحمد)"
+      },
+      {
+        "code": "GLS",
+        "name": "Golestan (گلستان)"
+      },
+      {
+        "code": "GIL",
+        "name": "Gilan (گیلان)"
+      },
+      {
+        "code": "MZN",
+        "name": "Mazandaran (مازندران)"
+      },
+      {
+        "code": "MKZ",
+        "name": "Markazi (مرکزی)"
+      },
+      {
+        "code": "HRZ",
+        "name": "Hormozgan (هرمزگان)"
+      },
+      {
+        "code": "SBN",
+        "name": "Sistan and Baluchestan (سیستان و بلوچستان)"
+      }
+    ]
+  },
+  {
+    "code": "IQ",
+    "name": "Iraq",
+    "states": []
+  },
+  {
+    "code": "IE",
+    "name": "Ireland",
+    "states": [
+      {
+        "code": "CW",
+        "name": "Carlow"
+      },
+      {
+        "code": "CN",
+        "name": "Cavan"
+      },
+      {
+        "code": "CE",
+        "name": "Clare"
+      },
+      {
+        "code": "CO",
+        "name": "Cork"
+      },
+      {
+        "code": "DL",
+        "name": "Donegal"
+      },
+      {
+        "code": "D",
+        "name": "Dublin"
+      },
+      {
+        "code": "G",
+        "name": "Galway"
+      },
+      {
+        "code": "KY",
+        "name": "Kerry"
+      },
+      {
+        "code": "KE",
+        "name": "Kildare"
+      },
+      {
+        "code": "KK",
+        "name": "Kilkenny"
+      },
+      {
+        "code": "LS",
+        "name": "Laois"
+      },
+      {
+        "code": "LM",
+        "name": "Leitrim"
+      },
+      {
+        "code": "LK",
+        "name": "Limerick"
+      },
+      {
+        "code": "LD",
+        "name": "Longford"
+      },
+      {
+        "code": "LH",
+        "name": "Louth"
+      },
+      {
+        "code": "MO",
+        "name": "Mayo"
+      },
+      {
+        "code": "MH",
+        "name": "Meath"
+      },
+      {
+        "code": "MN",
+        "name": "Monaghan"
+      },
+      {
+        "code": "OY",
+        "name": "Offaly"
+      },
+      {
+        "code": "RN",
+        "name": "Roscommon"
+      },
+      {
+        "code": "SO",
+        "name": "Sligo"
+      },
+      {
+        "code": "TA",
+        "name": "Tipperary"
+      },
+      {
+        "code": "WD",
+        "name": "Waterford"
+      },
+      {
+        "code": "WH",
+        "name": "Westmeath"
+      },
+      {
+        "code": "WX",
+        "name": "Wexford"
+      },
+      {
+        "code": "WW",
+        "name": "Wicklow"
+      }
+    ]
+  },
+  {
+    "code": "IM",
+    "name": "Isle of Man",
+    "states": []
+  },
+  {
+    "code": "IL",
+    "name": "Israel",
+    "states": []
+  },
+  {
+    "code": "IT",
+    "name": "Italy",
+    "states": [
+      {
+        "code": "AG",
+        "name": "Agrigento"
+      },
+      {
+        "code": "AL",
+        "name": "Alessandria"
+      },
+      {
+        "code": "AN",
+        "name": "Ancona"
+      },
+      {
+        "code": "AO",
+        "name": "Aosta"
+      },
+      {
+        "code": "AR",
+        "name": "Arezzo"
+      },
+      {
+        "code": "AP",
+        "name": "Ascoli Piceno"
+      },
+      {
+        "code": "AT",
+        "name": "Asti"
+      },
+      {
+        "code": "AV",
+        "name": "Avellino"
+      },
+      {
+        "code": "BA",
+        "name": "Bari"
+      },
+      {
+        "code": "BT",
+        "name": "Barletta-Andria-Trani"
+      },
+      {
+        "code": "BL",
+        "name": "Belluno"
+      },
+      {
+        "code": "BN",
+        "name": "Benevento"
+      },
+      {
+        "code": "BG",
+        "name": "Bergamo"
+      },
+      {
+        "code": "BI",
+        "name": "Biella"
+      },
+      {
+        "code": "BO",
+        "name": "Bologna"
+      },
+      {
+        "code": "BZ",
+        "name": "Bolzano"
+      },
+      {
+        "code": "BS",
+        "name": "Brescia"
+      },
+      {
+        "code": "BR",
+        "name": "Brindisi"
+      },
+      {
+        "code": "CA",
+        "name": "Cagliari"
+      },
+      {
+        "code": "CL",
+        "name": "Caltanissetta"
+      },
+      {
+        "code": "CB",
+        "name": "Campobasso"
+      },
+      {
+        "code": "CE",
+        "name": "Caserta"
+      },
+      {
+        "code": "CT",
+        "name": "Catania"
+      },
+      {
+        "code": "CZ",
+        "name": "Catanzaro"
+      },
+      {
+        "code": "CH",
+        "name": "Chieti"
+      },
+      {
+        "code": "CO",
+        "name": "Como"
+      },
+      {
+        "code": "CS",
+        "name": "Cosenza"
+      },
+      {
+        "code": "CR",
+        "name": "Cremona"
+      },
+      {
+        "code": "KR",
+        "name": "Crotone"
+      },
+      {
+        "code": "CN",
+        "name": "Cuneo"
+      },
+      {
+        "code": "EN",
+        "name": "Enna"
+      },
+      {
+        "code": "FM",
+        "name": "Fermo"
+      },
+      {
+        "code": "FE",
+        "name": "Ferrara"
+      },
+      {
+        "code": "FI",
+        "name": "Firenze"
+      },
+      {
+        "code": "FG",
+        "name": "Foggia"
+      },
+      {
+        "code": "FC",
+        "name": "Forlì-Cesena"
+      },
+      {
+        "code": "FR",
+        "name": "Frosinone"
+      },
+      {
+        "code": "GE",
+        "name": "Genova"
+      },
+      {
+        "code": "GO",
+        "name": "Gorizia"
+      },
+      {
+        "code": "GR",
+        "name": "Grosseto"
+      },
+      {
+        "code": "IM",
+        "name": "Imperia"
+      },
+      {
+        "code": "IS",
+        "name": "Isernia"
+      },
+      {
+        "code": "SP",
+        "name": "La Spezia"
+      },
+      {
+        "code": "AQ",
+        "name": "L'Aquila"
+      },
+      {
+        "code": "LT",
+        "name": "Latina"
+      },
+      {
+        "code": "LE",
+        "name": "Lecce"
+      },
+      {
+        "code": "LC",
+        "name": "Lecco"
+      },
+      {
+        "code": "LI",
+        "name": "Livorno"
+      },
+      {
+        "code": "LO",
+        "name": "Lodi"
+      },
+      {
+        "code": "LU",
+        "name": "Lucca"
+      },
+      {
+        "code": "MC",
+        "name": "Macerata"
+      },
+      {
+        "code": "MN",
+        "name": "Mantova"
+      },
+      {
+        "code": "MS",
+        "name": "Massa-Carrara"
+      },
+      {
+        "code": "MT",
+        "name": "Matera"
+      },
+      {
+        "code": "ME",
+        "name": "Messina"
+      },
+      {
+        "code": "MI",
+        "name": "Milano"
+      },
+      {
+        "code": "MO",
+        "name": "Modena"
+      },
+      {
+        "code": "MB",
+        "name": "Monza e della Brianza"
+      },
+      {
+        "code": "NA",
+        "name": "Napoli"
+      },
+      {
+        "code": "NO",
+        "name": "Novara"
+      },
+      {
+        "code": "NU",
+        "name": "Nuoro"
+      },
+      {
+        "code": "OR",
+        "name": "Oristano"
+      },
+      {
+        "code": "PD",
+        "name": "Padova"
+      },
+      {
+        "code": "PA",
+        "name": "Palermo"
+      },
+      {
+        "code": "PR",
+        "name": "Parma"
+      },
+      {
+        "code": "PV",
+        "name": "Pavia"
+      },
+      {
+        "code": "PG",
+        "name": "Perugia"
+      },
+      {
+        "code": "PU",
+        "name": "Pesaro e Urbino"
+      },
+      {
+        "code": "PE",
+        "name": "Pescara"
+      },
+      {
+        "code": "PC",
+        "name": "Piacenza"
+      },
+      {
+        "code": "PI",
+        "name": "Pisa"
+      },
+      {
+        "code": "PT",
+        "name": "Pistoia"
+      },
+      {
+        "code": "PN",
+        "name": "Pordenone"
+      },
+      {
+        "code": "PZ",
+        "name": "Potenza"
+      },
+      {
+        "code": "PO",
+        "name": "Prato"
+      },
+      {
+        "code": "RG",
+        "name": "Ragusa"
+      },
+      {
+        "code": "RA",
+        "name": "Ravenna"
+      },
+      {
+        "code": "RC",
+        "name": "Reggio Calabria"
+      },
+      {
+        "code": "RE",
+        "name": "Reggio Emilia"
+      },
+      {
+        "code": "RI",
+        "name": "Rieti"
+      },
+      {
+        "code": "RN",
+        "name": "Rimini"
+      },
+      {
+        "code": "RM",
+        "name": "Roma"
+      },
+      {
+        "code": "RO",
+        "name": "Rovigo"
+      },
+      {
+        "code": "SA",
+        "name": "Salerno"
+      },
+      {
+        "code": "SS",
+        "name": "Sassari"
+      },
+      {
+        "code": "SV",
+        "name": "Savona"
+      },
+      {
+        "code": "SI",
+        "name": "Siena"
+      },
+      {
+        "code": "SR",
+        "name": "Siracusa"
+      },
+      {
+        "code": "SO",
+        "name": "Sondrio"
+      },
+      {
+        "code": "SU",
+        "name": "Sud Sardegna"
+      },
+      {
+        "code": "TA",
+        "name": "Taranto"
+      },
+      {
+        "code": "TE",
+        "name": "Teramo"
+      },
+      {
+        "code": "TR",
+        "name": "Terni"
+      },
+      {
+        "code": "TO",
+        "name": "Torino"
+      },
+      {
+        "code": "TP",
+        "name": "Trapani"
+      },
+      {
+        "code": "TN",
+        "name": "Trento"
+      },
+      {
+        "code": "TV",
+        "name": "Treviso"
+      },
+      {
+        "code": "TS",
+        "name": "Trieste"
+      },
+      {
+        "code": "UD",
+        "name": "Udine"
+      },
+      {
+        "code": "VA",
+        "name": "Varese"
+      },
+      {
+        "code": "VE",
+        "name": "Venezia"
+      },
+      {
+        "code": "VB",
+        "name": "Verbano-Cusio-Ossola"
+      },
+      {
+        "code": "VC",
+        "name": "Vercelli"
+      },
+      {
+        "code": "VR",
+        "name": "Verona"
+      },
+      {
+        "code": "VV",
+        "name": "Vibo Valentia"
+      },
+      {
+        "code": "VI",
+        "name": "Vicenza"
+      },
+      {
+        "code": "VT",
+        "name": "Viterbo"
+      }
+    ]
+  },
+  {
+    "code": "CI",
+    "name": "Ivory Coast",
+    "states": []
+  },
+  {
+    "code": "JM",
+    "name": "Jamaica",
+    "states": [
+      {
+        "code": "JM-01",
+        "name": "Kingston"
+      },
+      {
+        "code": "JM-02",
+        "name": "Saint Andrew"
+      },
+      {
+        "code": "JM-03",
+        "name": "Saint Thomas"
+      },
+      {
+        "code": "JM-04",
+        "name": "Portland"
+      },
+      {
+        "code": "JM-05",
+        "name": "Saint Mary"
+      },
+      {
+        "code": "JM-06",
+        "name": "Saint Ann"
+      },
+      {
+        "code": "JM-07",
+        "name": "Trelawny"
+      },
+      {
+        "code": "JM-08",
+        "name": "Saint James"
+      },
+      {
+        "code": "JM-09",
+        "name": "Hanover"
+      },
+      {
+        "code": "JM-10",
+        "name": "Westmoreland"
+      },
+      {
+        "code": "JM-11",
+        "name": "Saint Elizabeth"
+      },
+      {
+        "code": "JM-12",
+        "name": "Manchester"
+      },
+      {
+        "code": "JM-13",
+        "name": "Clarendon"
+      },
+      {
+        "code": "JM-14",
+        "name": "Saint Catherine"
+      }
+    ]
+  },
+  {
+    "code": "JP",
+    "name": "Japan",
+    "states": [
+      {
+        "code": "JP01",
+        "name": "Hokkaido"
+      },
+      {
+        "code": "JP02",
+        "name": "Aomori"
+      },
+      {
+        "code": "JP03",
+        "name": "Iwate"
+      },
+      {
+        "code": "JP04",
+        "name": "Miyagi"
+      },
+      {
+        "code": "JP05",
+        "name": "Akita"
+      },
+      {
+        "code": "JP06",
+        "name": "Yamagata"
+      },
+      {
+        "code": "JP07",
+        "name": "Fukushima"
+      },
+      {
+        "code": "JP08",
+        "name": "Ibaraki"
+      },
+      {
+        "code": "JP09",
+        "name": "Tochigi"
+      },
+      {
+        "code": "JP10",
+        "name": "Gunma"
+      },
+      {
+        "code": "JP11",
+        "name": "Saitama"
+      },
+      {
+        "code": "JP12",
+        "name": "Chiba"
+      },
+      {
+        "code": "JP13",
+        "name": "Tokyo"
+      },
+      {
+        "code": "JP14",
+        "name": "Kanagawa"
+      },
+      {
+        "code": "JP15",
+        "name": "Niigata"
+      },
+      {
+        "code": "JP16",
+        "name": "Toyama"
+      },
+      {
+        "code": "JP17",
+        "name": "Ishikawa"
+      },
+      {
+        "code": "JP18",
+        "name": "Fukui"
+      },
+      {
+        "code": "JP19",
+        "name": "Yamanashi"
+      },
+      {
+        "code": "JP20",
+        "name": "Nagano"
+      },
+      {
+        "code": "JP21",
+        "name": "Gifu"
+      },
+      {
+        "code": "JP22",
+        "name": "Shizuoka"
+      },
+      {
+        "code": "JP23",
+        "name": "Aichi"
+      },
+      {
+        "code": "JP24",
+        "name": "Mie"
+      },
+      {
+        "code": "JP25",
+        "name": "Shiga"
+      },
+      {
+        "code": "JP26",
+        "name": "Kyoto"
+      },
+      {
+        "code": "JP27",
+        "name": "Osaka"
+      },
+      {
+        "code": "JP28",
+        "name": "Hyogo"
+      },
+      {
+        "code": "JP29",
+        "name": "Nara"
+      },
+      {
+        "code": "JP30",
+        "name": "Wakayama"
+      },
+      {
+        "code": "JP31",
+        "name": "Tottori"
+      },
+      {
+        "code": "JP32",
+        "name": "Shimane"
+      },
+      {
+        "code": "JP33",
+        "name": "Okayama"
+      },
+      {
+        "code": "JP34",
+        "name": "Hiroshima"
+      },
+      {
+        "code": "JP35",
+        "name": "Yamaguchi"
+      },
+      {
+        "code": "JP36",
+        "name": "Tokushima"
+      },
+      {
+        "code": "JP37",
+        "name": "Kagawa"
+      },
+      {
+        "code": "JP38",
+        "name": "Ehime"
+      },
+      {
+        "code": "JP39",
+        "name": "Kochi"
+      },
+      {
+        "code": "JP40",
+        "name": "Fukuoka"
+      },
+      {
+        "code": "JP41",
+        "name": "Saga"
+      },
+      {
+        "code": "JP42",
+        "name": "Nagasaki"
+      },
+      {
+        "code": "JP43",
+        "name": "Kumamoto"
+      },
+      {
+        "code": "JP44",
+        "name": "Oita"
+      },
+      {
+        "code": "JP45",
+        "name": "Miyazaki"
+      },
+      {
+        "code": "JP46",
+        "name": "Kagoshima"
+      },
+      {
+        "code": "JP47",
+        "name": "Okinawa"
+      }
+    ]
+  },
+  {
+    "code": "JE",
+    "name": "Jersey",
+    "states": []
+  },
+  {
+    "code": "JO",
+    "name": "Jordan",
+    "states": []
+  },
+  {
+    "code": "KZ",
+    "name": "Kazakhstan",
+    "states": []
+  },
+  {
+    "code": "KE",
+    "name": "Kenya",
+    "states": [
+      {
+        "code": "KE01",
+        "name": "Baringo"
+      },
+      {
+        "code": "KE02",
+        "name": "Bomet"
+      },
+      {
+        "code": "KE03",
+        "name": "Bungoma"
+      },
+      {
+        "code": "KE04",
+        "name": "Busia"
+      },
+      {
+        "code": "KE05",
+        "name": "Elgeyo-Marakwet"
+      },
+      {
+        "code": "KE06",
+        "name": "Embu"
+      },
+      {
+        "code": "KE07",
+        "name": "Garissa"
+      },
+      {
+        "code": "KE08",
+        "name": "Homa Bay"
+      },
+      {
+        "code": "KE09",
+        "name": "Isiolo"
+      },
+      {
+        "code": "KE10",
+        "name": "Kajiado"
+      },
+      {
+        "code": "KE11",
+        "name": "Kakamega"
+      },
+      {
+        "code": "KE12",
+        "name": "Kericho"
+      },
+      {
+        "code": "KE13",
+        "name": "Kiambu"
+      },
+      {
+        "code": "KE14",
+        "name": "Kilifi"
+      },
+      {
+        "code": "KE15",
+        "name": "Kirinyaga"
+      },
+      {
+        "code": "KE16",
+        "name": "Kisii"
+      },
+      {
+        "code": "KE17",
+        "name": "Kisumu"
+      },
+      {
+        "code": "KE18",
+        "name": "Kitui"
+      },
+      {
+        "code": "KE19",
+        "name": "Kwale"
+      },
+      {
+        "code": "KE20",
+        "name": "Laikipia"
+      },
+      {
+        "code": "KE21",
+        "name": "Lamu"
+      },
+      {
+        "code": "KE22",
+        "name": "Machakos"
+      },
+      {
+        "code": "KE23",
+        "name": "Makueni"
+      },
+      {
+        "code": "KE24",
+        "name": "Mandera"
+      },
+      {
+        "code": "KE25",
+        "name": "Marsabit"
+      },
+      {
+        "code": "KE26",
+        "name": "Meru"
+      },
+      {
+        "code": "KE27",
+        "name": "Migori"
+      },
+      {
+        "code": "KE28",
+        "name": "Mombasa"
+      },
+      {
+        "code": "KE29",
+        "name": "Murang’a"
+      },
+      {
+        "code": "KE30",
+        "name": "Nairobi County"
+      },
+      {
+        "code": "KE31",
+        "name": "Nakuru"
+      },
+      {
+        "code": "KE32",
+        "name": "Nandi"
+      },
+      {
+        "code": "KE33",
+        "name": "Narok"
+      },
+      {
+        "code": "KE34",
+        "name": "Nyamira"
+      },
+      {
+        "code": "KE35",
+        "name": "Nyandarua"
+      },
+      {
+        "code": "KE36",
+        "name": "Nyeri"
+      },
+      {
+        "code": "KE37",
+        "name": "Samburu"
+      },
+      {
+        "code": "KE38",
+        "name": "Siaya"
+      },
+      {
+        "code": "KE39",
+        "name": "Taita-Taveta"
+      },
+      {
+        "code": "KE40",
+        "name": "Tana River"
+      },
+      {
+        "code": "KE41",
+        "name": "Tharaka-Nithi"
+      },
+      {
+        "code": "KE42",
+        "name": "Trans Nzoia"
+      },
+      {
+        "code": "KE43",
+        "name": "Turkana"
+      },
+      {
+        "code": "KE44",
+        "name": "Uasin Gishu"
+      },
+      {
+        "code": "KE45",
+        "name": "Vihiga"
+      },
+      {
+        "code": "KE46",
+        "name": "Wajir"
+      },
+      {
+        "code": "KE47",
+        "name": "West Pokot"
+      }
+    ]
+  },
+  {
+    "code": "KI",
+    "name": "Kiribati",
+    "states": []
+  },
+  {
+    "code": "KW",
+    "name": "Kuwait",
+    "states": []
+  },
+  {
+    "code": "KG",
+    "name": "Kyrgyzstan",
+    "states": []
+  },
+  {
+    "code": "LA",
+    "name": "Laos",
+    "states": [
+      {
+        "code": "AT",
+        "name": "Attapeu"
+      },
+      {
+        "code": "BK",
+        "name": "Bokeo"
+      },
+      {
+        "code": "BL",
+        "name": "Bolikhamsai"
+      },
+      {
+        "code": "CH",
+        "name": "Champasak"
+      },
+      {
+        "code": "HO",
+        "name": "Houaphanh"
+      },
+      {
+        "code": "KH",
+        "name": "Khammouane"
+      },
+      {
+        "code": "LM",
+        "name": "Luang Namtha"
+      },
+      {
+        "code": "LP",
+        "name": "Luang Prabang"
+      },
+      {
+        "code": "OU",
+        "name": "Oudomxay"
+      },
+      {
+        "code": "PH",
+        "name": "Phongsaly"
+      },
+      {
+        "code": "SL",
+        "name": "Salavan"
+      },
+      {
+        "code": "SV",
+        "name": "Savannakhet"
+      },
+      {
+        "code": "VI",
+        "name": "Vientiane Province"
+      },
+      {
+        "code": "VT",
+        "name": "Vientiane"
+      },
+      {
+        "code": "XA",
+        "name": "Sainyabuli"
+      },
+      {
+        "code": "XE",
+        "name": "Sekong"
+      },
+      {
+        "code": "XI",
+        "name": "Xiangkhouang"
+      },
+      {
+        "code": "XS",
+        "name": "Xaisomboun"
+      }
+    ]
+  },
+  {
+    "code": "LV",
+    "name": "Latvia",
+    "states": []
+  },
+  {
+    "code": "LB",
+    "name": "Lebanon",
+    "states": []
+  },
+  {
+    "code": "LS",
+    "name": "Lesotho",
+    "states": []
+  },
+  {
+    "code": "LR",
+    "name": "Liberia",
+    "states": [
+      {
+        "code": "BM",
+        "name": "Bomi"
+      },
+      {
+        "code": "BN",
+        "name": "Bong"
+      },
+      {
+        "code": "GA",
+        "name": "Gbarpolu"
+      },
+      {
+        "code": "GB",
+        "name": "Grand Bassa"
+      },
+      {
+        "code": "GC",
+        "name": "Grand Cape Mount"
+      },
+      {
+        "code": "GG",
+        "name": "Grand Gedeh"
+      },
+      {
+        "code": "GK",
+        "name": "Grand Kru"
+      },
+      {
+        "code": "LO",
+        "name": "Lofa"
+      },
+      {
+        "code": "MA",
+        "name": "Margibi"
+      },
+      {
+        "code": "MY",
+        "name": "Maryland"
+      },
+      {
+        "code": "MO",
+        "name": "Montserrado"
+      },
+      {
+        "code": "NM",
+        "name": "Nimba"
+      },
+      {
+        "code": "RV",
+        "name": "Rivercess"
+      },
+      {
+        "code": "RG",
+        "name": "River Gee"
+      },
+      {
+        "code": "SN",
+        "name": "Sinoe"
+      }
+    ]
+  },
+  {
+    "code": "LY",
+    "name": "Libya",
+    "states": []
+  },
+  {
+    "code": "LI",
+    "name": "Liechtenstein",
+    "states": []
+  },
+  {
+    "code": "LT",
+    "name": "Lithuania",
+    "states": []
+  },
+  {
+    "code": "LU",
+    "name": "Luxembourg",
+    "states": []
+  },
+  {
+    "code": "MO",
+    "name": "Macao",
+    "states": []
+  },
+  {
+    "code": "MG",
+    "name": "Madagascar",
+    "states": []
+  },
+  {
+    "code": "MW",
+    "name": "Malawi",
+    "states": []
+  },
+  {
+    "code": "MY",
+    "name": "Malaysia",
+    "states": [
+      {
+        "code": "JHR",
+        "name": "Johor"
+      },
+      {
+        "code": "KDH",
+        "name": "Kedah"
+      },
+      {
+        "code": "KTN",
+        "name": "Kelantan"
+      },
+      {
+        "code": "LBN",
+        "name": "Labuan"
+      },
+      {
+        "code": "MLK",
+        "name": "Malacca (Melaka)"
+      },
+      {
+        "code": "NSN",
+        "name": "Negeri Sembilan"
+      },
+      {
+        "code": "PHG",
+        "name": "Pahang"
+      },
+      {
+        "code": "PNG",
+        "name": "Penang (Pulau Pinang)"
+      },
+      {
+        "code": "PRK",
+        "name": "Perak"
+      },
+      {
+        "code": "PLS",
+        "name": "Perlis"
+      },
+      {
+        "code": "SBH",
+        "name": "Sabah"
+      },
+      {
+        "code": "SWK",
+        "name": "Sarawak"
+      },
+      {
+        "code": "SGR",
+        "name": "Selangor"
+      },
+      {
+        "code": "TRG",
+        "name": "Terengganu"
+      },
+      {
+        "code": "PJY",
+        "name": "Putrajaya"
+      },
+      {
+        "code": "KUL",
+        "name": "Kuala Lumpur"
+      }
+    ]
+  },
+  {
+    "code": "MV",
+    "name": "Maldives",
+    "states": []
+  },
+  {
+    "code": "ML",
+    "name": "Mali",
+    "states": []
+  },
+  {
+    "code": "MT",
+    "name": "Malta",
+    "states": []
+  },
+  {
+    "code": "MH",
+    "name": "Marshall Islands",
+    "states": []
+  },
+  {
+    "code": "MQ",
+    "name": "Martinique",
+    "states": []
+  },
+  {
+    "code": "MR",
+    "name": "Mauritania",
+    "states": []
+  },
+  {
+    "code": "MU",
+    "name": "Mauritius",
+    "states": []
+  },
+  {
+    "code": "YT",
+    "name": "Mayotte",
+    "states": []
+  },
+  {
+    "code": "MX",
+    "name": "Mexico",
+    "states": [
+      {
+        "code": "DF",
+        "name": "Ciudad de México"
+      },
+      {
+        "code": "JA",
+        "name": "Jalisco"
+      },
+      {
+        "code": "NL",
+        "name": "Nuevo León"
+      },
+      {
+        "code": "AG",
+        "name": "Aguascalientes"
+      },
+      {
+        "code": "BC",
+        "name": "Baja California"
+      },
+      {
+        "code": "BS",
+        "name": "Baja California Sur"
+      },
+      {
+        "code": "CM",
+        "name": "Campeche"
+      },
+      {
+        "code": "CS",
+        "name": "Chiapas"
+      },
+      {
+        "code": "CH",
+        "name": "Chihuahua"
+      },
+      {
+        "code": "CO",
+        "name": "Coahuila"
+      },
+      {
+        "code": "CL",
+        "name": "Colima"
+      },
+      {
+        "code": "DG",
+        "name": "Durango"
+      },
+      {
+        "code": "GT",
+        "name": "Guanajuato"
+      },
+      {
+        "code": "GR",
+        "name": "Guerrero"
+      },
+      {
+        "code": "HG",
+        "name": "Hidalgo"
+      },
+      {
+        "code": "MX",
+        "name": "Estado de México"
+      },
+      {
+        "code": "MI",
+        "name": "Michoacán"
+      },
+      {
+        "code": "MO",
+        "name": "Morelos"
+      },
+      {
+        "code": "NA",
+        "name": "Nayarit"
+      },
+      {
+        "code": "OA",
+        "name": "Oaxaca"
+      },
+      {
+        "code": "PU",
+        "name": "Puebla"
+      },
+      {
+        "code": "QT",
+        "name": "Querétaro"
+      },
+      {
+        "code": "QR",
+        "name": "Quintana Roo"
+      },
+      {
+        "code": "SL",
+        "name": "San Luis Potosí"
+      },
+      {
+        "code": "SI",
+        "name": "Sinaloa"
+      },
+      {
+        "code": "SO",
+        "name": "Sonora"
+      },
+      {
+        "code": "TB",
+        "name": "Tabasco"
+      },
+      {
+        "code": "TM",
+        "name": "Tamaulipas"
+      },
+      {
+        "code": "TL",
+        "name": "Tlaxcala"
+      },
+      {
+        "code": "VE",
+        "name": "Veracruz"
+      },
+      {
+        "code": "YU",
+        "name": "Yucatán"
+      },
+      {
+        "code": "ZA",
+        "name": "Zacatecas"
+      }
+    ]
+  },
+  {
+    "code": "FM",
+    "name": "Micronesia",
+    "states": []
+  },
+  {
+    "code": "MD",
+    "name": "Moldova",
+    "states": [
+      {
+        "code": "C",
+        "name": "Chișinău"
+      },
+      {
+        "code": "BL",
+        "name": "Bălți"
+      },
+      {
+        "code": "AN",
+        "name": "Anenii Noi"
+      },
+      {
+        "code": "BS",
+        "name": "Basarabeasca"
+      },
+      {
+        "code": "BR",
+        "name": "Briceni"
+      },
+      {
+        "code": "CH",
+        "name": "Cahul"
+      },
+      {
+        "code": "CT",
+        "name": "Cantemir"
+      },
+      {
+        "code": "CL",
+        "name": "Călărași"
+      },
+      {
+        "code": "CS",
+        "name": "Căușeni"
+      },
+      {
+        "code": "CM",
+        "name": "Cimișlia"
+      },
+      {
+        "code": "CR",
+        "name": "Criuleni"
+      },
+      {
+        "code": "DN",
+        "name": "Dondușeni"
+      },
+      {
+        "code": "DR",
+        "name": "Drochia"
+      },
+      {
+        "code": "DB",
+        "name": "Dubăsari"
+      },
+      {
+        "code": "ED",
+        "name": "Edineț"
+      },
+      {
+        "code": "FL",
+        "name": "Fălești"
+      },
+      {
+        "code": "FR",
+        "name": "Florești"
+      },
+      {
+        "code": "GE",
+        "name": "UTA Găgăuzia"
+      },
+      {
+        "code": "GL",
+        "name": "Glodeni"
+      },
+      {
+        "code": "HN",
+        "name": "Hîncești"
+      },
+      {
+        "code": "IL",
+        "name": "Ialoveni"
+      },
+      {
+        "code": "LV",
+        "name": "Leova"
+      },
+      {
+        "code": "NS",
+        "name": "Nisporeni"
+      },
+      {
+        "code": "OC",
+        "name": "Ocnița"
+      },
+      {
+        "code": "OR",
+        "name": "Orhei"
+      },
+      {
+        "code": "RZ",
+        "name": "Rezina"
+      },
+      {
+        "code": "RS",
+        "name": "Rîșcani"
+      },
+      {
+        "code": "SG",
+        "name": "Sîngerei"
+      },
+      {
+        "code": "SR",
+        "name": "Soroca"
+      },
+      {
+        "code": "ST",
+        "name": "Strășeni"
+      },
+      {
+        "code": "SD",
+        "name": "Șoldănești"
+      },
+      {
+        "code": "SV",
+        "name": "Ștefan Vodă"
+      },
+      {
+        "code": "TR",
+        "name": "Taraclia"
+      },
+      {
+        "code": "TL",
+        "name": "Telenești"
+      },
+      {
+        "code": "UN",
+        "name": "Ungheni"
+      }
+    ]
+  },
+  {
+    "code": "MC",
+    "name": "Monaco",
+    "states": []
+  },
+  {
+    "code": "MN",
+    "name": "Mongolia",
+    "states": []
+  },
+  {
+    "code": "ME",
+    "name": "Montenegro",
+    "states": []
+  },
+  {
+    "code": "MS",
+    "name": "Montserrat",
+    "states": []
+  },
+  {
+    "code": "MA",
+    "name": "Morocco",
+    "states": []
+  },
+  {
+    "code": "MZ",
+    "name": "Mozambique",
+    "states": [
+      {
+        "code": "MZP",
+        "name": "Cabo Delgado"
+      },
+      {
+        "code": "MZG",
+        "name": "Gaza"
+      },
+      {
+        "code": "MZI",
+        "name": "Inhambane"
+      },
+      {
+        "code": "MZB",
+        "name": "Manica"
+      },
+      {
+        "code": "MZL",
+        "name": "Maputo Province"
+      },
+      {
+        "code": "MZMPM",
+        "name": "Maputo"
+      },
+      {
+        "code": "MZN",
+        "name": "Nampula"
+      },
+      {
+        "code": "MZA",
+        "name": "Niassa"
+      },
+      {
+        "code": "MZS",
+        "name": "Sofala"
+      },
+      {
+        "code": "MZT",
+        "name": "Tete"
+      },
+      {
+        "code": "MZQ",
+        "name": "Zambézia"
+      }
+    ]
+  },
+  {
+    "code": "MM",
+    "name": "Myanmar",
+    "states": []
+  },
+  {
+    "code": "NA",
+    "name": "Namibia",
+    "states": [
+      {
+        "code": "ER",
+        "name": "Erongo"
+      },
+      {
+        "code": "HA",
+        "name": "Hardap"
+      },
+      {
+        "code": "KA",
+        "name": "Karas"
+      },
+      {
+        "code": "KE",
+        "name": "Kavango East"
+      },
+      {
+        "code": "KW",
+        "name": "Kavango West"
+      },
+      {
+        "code": "KH",
+        "name": "Khomas"
+      },
+      {
+        "code": "KU",
+        "name": "Kunene"
+      },
+      {
+        "code": "OW",
+        "name": "Ohangwena"
+      },
+      {
+        "code": "OH",
+        "name": "Omaheke"
+      },
+      {
+        "code": "OS",
+        "name": "Omusati"
+      },
+      {
+        "code": "ON",
+        "name": "Oshana"
+      },
+      {
+        "code": "OT",
+        "name": "Oshikoto"
+      },
+      {
+        "code": "OD",
+        "name": "Otjozondjupa"
+      },
+      {
+        "code": "CA",
+        "name": "Zambezi"
+      }
+    ]
+  },
+  {
+    "code": "NR",
+    "name": "Nauru",
+    "states": []
+  },
+  {
+    "code": "NP",
+    "name": "Nepal",
+    "states": [
+      {
+        "code": "BAG",
+        "name": "Bagmati"
+      },
+      {
+        "code": "BHE",
+        "name": "Bheri"
+      },
+      {
+        "code": "DHA",
+        "name": "Dhaulagiri"
+      },
+      {
+        "code": "GAN",
+        "name": "Gandaki"
+      },
+      {
+        "code": "JAN",
+        "name": "Janakpur"
+      },
+      {
+        "code": "KAR",
+        "name": "Karnali"
+      },
+      {
+        "code": "KOS",
+        "name": "Koshi"
+      },
+      {
+        "code": "LUM",
+        "name": "Lumbini"
+      },
+      {
+        "code": "MAH",
+        "name": "Mahakali"
+      },
+      {
+        "code": "MEC",
+        "name": "Mechi"
+      },
+      {
+        "code": "NAR",
+        "name": "Narayani"
+      },
+      {
+        "code": "RAP",
+        "name": "Rapti"
+      },
+      {
+        "code": "SAG",
+        "name": "Sagarmatha"
+      },
+      {
+        "code": "SET",
+        "name": "Seti"
+      }
+    ]
+  },
+  {
+    "code": "NL",
+    "name": "Netherlands",
+    "states": []
+  },
+  {
+    "code": "NC",
+    "name": "New Caledonia",
+    "states": []
+  },
+  {
+    "code": "NZ",
+    "name": "New Zealand",
+    "states": [
+      {
+        "code": "NTL",
+        "name": "Northland"
+      },
+      {
+        "code": "AUK",
+        "name": "Auckland"
+      },
+      {
+        "code": "WKO",
+        "name": "Waikato"
+      },
+      {
+        "code": "BOP",
+        "name": "Bay of Plenty"
+      },
+      {
+        "code": "TKI",
+        "name": "Taranaki"
+      },
+      {
+        "code": "GIS",
+        "name": "Gisborne"
+      },
+      {
+        "code": "HKB",
+        "name": "Hawke’s Bay"
+      },
+      {
+        "code": "MWT",
+        "name": "Manawatu-Wanganui"
+      },
+      {
+        "code": "WGN",
+        "name": "Wellington"
+      },
+      {
+        "code": "NSN",
+        "name": "Nelson"
+      },
+      {
+        "code": "MBH",
+        "name": "Marlborough"
+      },
+      {
+        "code": "TAS",
+        "name": "Tasman"
+      },
+      {
+        "code": "WTC",
+        "name": "West Coast"
+      },
+      {
+        "code": "CAN",
+        "name": "Canterbury"
+      },
+      {
+        "code": "OTA",
+        "name": "Otago"
+      },
+      {
+        "code": "STL",
+        "name": "Southland"
+      }
+    ]
+  },
+  {
+    "code": "NI",
+    "name": "Nicaragua",
+    "states": [
+      {
+        "code": "NI-AN",
+        "name": "Atlántico Norte"
+      },
+      {
+        "code": "NI-AS",
+        "name": "Atlántico Sur"
+      },
+      {
+        "code": "NI-BO",
+        "name": "Boaco"
+      },
+      {
+        "code": "NI-CA",
+        "name": "Carazo"
+      },
+      {
+        "code": "NI-CI",
+        "name": "Chinandega"
+      },
+      {
+        "code": "NI-CO",
+        "name": "Chontales"
+      },
+      {
+        "code": "NI-ES",
+        "name": "Estelí"
+      },
+      {
+        "code": "NI-GR",
+        "name": "Granada"
+      },
+      {
+        "code": "NI-JI",
+        "name": "Jinotega"
+      },
+      {
+        "code": "NI-LE",
+        "name": "León"
+      },
+      {
+        "code": "NI-MD",
+        "name": "Madriz"
+      },
+      {
+        "code": "NI-MN",
+        "name": "Managua"
+      },
+      {
+        "code": "NI-MS",
+        "name": "Masaya"
+      },
+      {
+        "code": "NI-MT",
+        "name": "Matagalpa"
+      },
+      {
+        "code": "NI-NS",
+        "name": "Nueva Segovia"
+      },
+      {
+        "code": "NI-RI",
+        "name": "Rivas"
+      },
+      {
+        "code": "NI-SJ",
+        "name": "Río San Juan"
+      }
+    ]
+  },
+  {
+    "code": "NE",
+    "name": "Niger",
+    "states": []
+  },
+  {
+    "code": "NG",
+    "name": "Nigeria",
+    "states": [
+      {
+        "code": "AB",
+        "name": "Abia"
+      },
+      {
+        "code": "FC",
+        "name": "Abuja"
+      },
+      {
+        "code": "AD",
+        "name": "Adamawa"
+      },
+      {
+        "code": "AK",
+        "name": "Akwa Ibom"
+      },
+      {
+        "code": "AN",
+        "name": "Anambra"
+      },
+      {
+        "code": "BA",
+        "name": "Bauchi"
+      },
+      {
+        "code": "BY",
+        "name": "Bayelsa"
+      },
+      {
+        "code": "BE",
+        "name": "Benue"
+      },
+      {
+        "code": "BO",
+        "name": "Borno"
+      },
+      {
+        "code": "CR",
+        "name": "Cross River"
+      },
+      {
+        "code": "DE",
+        "name": "Delta"
+      },
+      {
+        "code": "EB",
+        "name": "Ebonyi"
+      },
+      {
+        "code": "ED",
+        "name": "Edo"
+      },
+      {
+        "code": "EK",
+        "name": "Ekiti"
+      },
+      {
+        "code": "EN",
+        "name": "Enugu"
+      },
+      {
+        "code": "GO",
+        "name": "Gombe"
+      },
+      {
+        "code": "IM",
+        "name": "Imo"
+      },
+      {
+        "code": "JI",
+        "name": "Jigawa"
+      },
+      {
+        "code": "KD",
+        "name": "Kaduna"
+      },
+      {
+        "code": "KN",
+        "name": "Kano"
+      },
+      {
+        "code": "KT",
+        "name": "Katsina"
+      },
+      {
+        "code": "KE",
+        "name": "Kebbi"
+      },
+      {
+        "code": "KO",
+        "name": "Kogi"
+      },
+      {
+        "code": "KW",
+        "name": "Kwara"
+      },
+      {
+        "code": "LA",
+        "name": "Lagos"
+      },
+      {
+        "code": "NA",
+        "name": "Nasarawa"
+      },
+      {
+        "code": "NI",
+        "name": "Niger"
+      },
+      {
+        "code": "OG",
+        "name": "Ogun"
+      },
+      {
+        "code": "ON",
+        "name": "Ondo"
+      },
+      {
+        "code": "OS",
+        "name": "Osun"
+      },
+      {
+        "code": "OY",
+        "name": "Oyo"
+      },
+      {
+        "code": "PL",
+        "name": "Plateau"
+      },
+      {
+        "code": "RI",
+        "name": "Rivers"
+      },
+      {
+        "code": "SO",
+        "name": "Sokoto"
+      },
+      {
+        "code": "TA",
+        "name": "Taraba"
+      },
+      {
+        "code": "YO",
+        "name": "Yobe"
+      },
+      {
+        "code": "ZA",
+        "name": "Zamfara"
+      }
+    ]
+  },
+  {
+    "code": "NU",
+    "name": "Niue",
+    "states": []
+  },
+  {
+    "code": "NF",
+    "name": "Norfolk Island",
+    "states": []
+  },
+  {
+    "code": "KP",
+    "name": "North Korea",
+    "states": []
+  },
+  {
+    "code": "MK",
+    "name": "North Macedonia",
+    "states": []
+  },
+  {
+    "code": "MP",
+    "name": "Northern Mariana Islands",
+    "states": []
+  },
+  {
+    "code": "NO",
+    "name": "Norway",
+    "states": []
+  },
+  {
+    "code": "OM",
+    "name": "Oman",
+    "states": []
+  },
+  {
+    "code": "PK",
+    "name": "Pakistan",
+    "states": [
+      {
+        "code": "JK",
+        "name": "Azad Kashmir"
+      },
+      {
+        "code": "BA",
+        "name": "Balochistan"
+      },
+      {
+        "code": "TA",
+        "name": "FATA"
+      },
+      {
+        "code": "GB",
+        "name": "Gilgit Baltistan"
+      },
+      {
+        "code": "IS",
+        "name": "Islamabad Capital Territory"
+      },
+      {
+        "code": "KP",
+        "name": "Khyber Pakhtunkhwa"
+      },
+      {
+        "code": "PB",
+        "name": "Punjab"
+      },
+      {
+        "code": "SD",
+        "name": "Sindh"
+      }
+    ]
+  },
+  {
+    "code": "PS",
+    "name": "Palestinian Territory",
+    "states": []
+  },
+  {
+    "code": "PA",
+    "name": "Panama",
+    "states": [
+      {
+        "code": "PA-1",
+        "name": "Bocas del Toro"
+      },
+      {
+        "code": "PA-2",
+        "name": "Coclé"
+      },
+      {
+        "code": "PA-3",
+        "name": "Colón"
+      },
+      {
+        "code": "PA-4",
+        "name": "Chiriquí"
+      },
+      {
+        "code": "PA-5",
+        "name": "Darién"
+      },
+      {
+        "code": "PA-6",
+        "name": "Herrera"
+      },
+      {
+        "code": "PA-7",
+        "name": "Los Santos"
+      },
+      {
+        "code": "PA-8",
+        "name": "Panamá"
+      },
+      {
+        "code": "PA-9",
+        "name": "Veraguas"
+      },
+      {
+        "code": "PA-10",
+        "name": "West Panamá"
+      },
+      {
+        "code": "PA-EM",
+        "name": "Emberá"
+      },
+      {
+        "code": "PA-KY",
+        "name": "Guna Yala"
+      },
+      {
+        "code": "PA-NB",
+        "name": "Ngöbe-Buglé"
+      }
+    ]
+  },
+  {
+    "code": "PG",
+    "name": "Papua New Guinea",
+    "states": []
+  },
+  {
+    "code": "PY",
+    "name": "Paraguay",
+    "states": [
+      {
+        "code": "PY-ASU",
+        "name": "Asunción"
+      },
+      {
+        "code": "PY-1",
+        "name": "Concepción"
+      },
+      {
+        "code": "PY-2",
+        "name": "San Pedro"
+      },
+      {
+        "code": "PY-3",
+        "name": "Cordillera"
+      },
+      {
+        "code": "PY-4",
+        "name": "Guairá"
+      },
+      {
+        "code": "PY-5",
+        "name": "Caaguazú"
+      },
+      {
+        "code": "PY-6",
+        "name": "Caazapá"
+      },
+      {
+        "code": "PY-7",
+        "name": "Itapúa"
+      },
+      {
+        "code": "PY-8",
+        "name": "Misiones"
+      },
+      {
+        "code": "PY-9",
+        "name": "Paraguarí"
+      },
+      {
+        "code": "PY-10",
+        "name": "Alto Paraná"
+      },
+      {
+        "code": "PY-11",
+        "name": "Central"
+      },
+      {
+        "code": "PY-12",
+        "name": "Ñeembucú"
+      },
+      {
+        "code": "PY-13",
+        "name": "Amambay"
+      },
+      {
+        "code": "PY-14",
+        "name": "Canindeyú"
+      },
+      {
+        "code": "PY-15",
+        "name": "Presidente Hayes"
+      },
+      {
+        "code": "PY-16",
+        "name": "Alto Paraguay"
+      },
+      {
+        "code": "PY-17",
+        "name": "Boquerón"
+      }
+    ]
+  },
+  {
+    "code": "PE",
+    "name": "Peru",
+    "states": [
+      {
+        "code": "CAL",
+        "name": "El Callao"
+      },
+      {
+        "code": "LMA",
+        "name": "Municipalidad Metropolitana de Lima"
+      },
+      {
+        "code": "AMA",
+        "name": "Amazonas"
+      },
+      {
+        "code": "ANC",
+        "name": "Ancash"
+      },
+      {
+        "code": "APU",
+        "name": "Apurímac"
+      },
+      {
+        "code": "ARE",
+        "name": "Arequipa"
+      },
+      {
+        "code": "AYA",
+        "name": "Ayacucho"
+      },
+      {
+        "code": "CAJ",
+        "name": "Cajamarca"
+      },
+      {
+        "code": "CUS",
+        "name": "Cusco"
+      },
+      {
+        "code": "HUV",
+        "name": "Huancavelica"
+      },
+      {
+        "code": "HUC",
+        "name": "Huánuco"
+      },
+      {
+        "code": "ICA",
+        "name": "Ica"
+      },
+      {
+        "code": "JUN",
+        "name": "Junín"
+      },
+      {
+        "code": "LAL",
+        "name": "La Libertad"
+      },
+      {
+        "code": "LAM",
+        "name": "Lambayeque"
+      },
+      {
+        "code": "LIM",
+        "name": "Lima"
+      },
+      {
+        "code": "LOR",
+        "name": "Loreto"
+      },
+      {
+        "code": "MDD",
+        "name": "Madre de Dios"
+      },
+      {
+        "code": "MOQ",
+        "name": "Moquegua"
+      },
+      {
+        "code": "PAS",
+        "name": "Pasco"
+      },
+      {
+        "code": "PIU",
+        "name": "Piura"
+      },
+      {
+        "code": "PUN",
+        "name": "Puno"
+      },
+      {
+        "code": "SAM",
+        "name": "San Martín"
+      },
+      {
+        "code": "TAC",
+        "name": "Tacna"
+      },
+      {
+        "code": "TUM",
+        "name": "Tumbes"
+      },
+      {
+        "code": "UCA",
+        "name": "Ucayali"
+      }
+    ]
+  },
+  {
+    "code": "PH",
+    "name": "Philippines",
+    "states": [
+      {
+        "code": "ABR",
+        "name": "Abra"
+      },
+      {
+        "code": "AGN",
+        "name": "Agusan del Norte"
+      },
+      {
+        "code": "AGS",
+        "name": "Agusan del Sur"
+      },
+      {
+        "code": "AKL",
+        "name": "Aklan"
+      },
+      {
+        "code": "ALB",
+        "name": "Albay"
+      },
+      {
+        "code": "ANT",
+        "name": "Antique"
+      },
+      {
+        "code": "APA",
+        "name": "Apayao"
+      },
+      {
+        "code": "AUR",
+        "name": "Aurora"
+      },
+      {
+        "code": "BAS",
+        "name": "Basilan"
+      },
+      {
+        "code": "BAN",
+        "name": "Bataan"
+      },
+      {
+        "code": "BTN",
+        "name": "Batanes"
+      },
+      {
+        "code": "BTG",
+        "name": "Batangas"
+      },
+      {
+        "code": "BEN",
+        "name": "Benguet"
+      },
+      {
+        "code": "BIL",
+        "name": "Biliran"
+      },
+      {
+        "code": "BOH",
+        "name": "Bohol"
+      },
+      {
+        "code": "BUK",
+        "name": "Bukidnon"
+      },
+      {
+        "code": "BUL",
+        "name": "Bulacan"
+      },
+      {
+        "code": "CAG",
+        "name": "Cagayan"
+      },
+      {
+        "code": "CAN",
+        "name": "Camarines Norte"
+      },
+      {
+        "code": "CAS",
+        "name": "Camarines Sur"
+      },
+      {
+        "code": "CAM",
+        "name": "Camiguin"
+      },
+      {
+        "code": "CAP",
+        "name": "Capiz"
+      },
+      {
+        "code": "CAT",
+        "name": "Catanduanes"
+      },
+      {
+        "code": "CAV",
+        "name": "Cavite"
+      },
+      {
+        "code": "CEB",
+        "name": "Cebu"
+      },
+      {
+        "code": "COM",
+        "name": "Compostela Valley"
+      },
+      {
+        "code": "NCO",
+        "name": "Cotabato"
+      },
+      {
+        "code": "DAV",
+        "name": "Davao del Norte"
+      },
+      {
+        "code": "DAS",
+        "name": "Davao del Sur"
+      },
+      {
+        "code": "DAC",
+        "name": "Davao Occidental"
+      },
+      {
+        "code": "DAO",
+        "name": "Davao Oriental"
+      },
+      {
+        "code": "DIN",
+        "name": "Dinagat Islands"
+      },
+      {
+        "code": "EAS",
+        "name": "Eastern Samar"
+      },
+      {
+        "code": "GUI",
+        "name": "Guimaras"
+      },
+      {
+        "code": "IFU",
+        "name": "Ifugao"
+      },
+      {
+        "code": "ILN",
+        "name": "Ilocos Norte"
+      },
+      {
+        "code": "ILS",
+        "name": "Ilocos Sur"
+      },
+      {
+        "code": "ILI",
+        "name": "Iloilo"
+      },
+      {
+        "code": "ISA",
+        "name": "Isabela"
+      },
+      {
+        "code": "KAL",
+        "name": "Kalinga"
+      },
+      {
+        "code": "LUN",
+        "name": "La Union"
+      },
+      {
+        "code": "LAG",
+        "name": "Laguna"
+      },
+      {
+        "code": "LAN",
+        "name": "Lanao del Norte"
+      },
+      {
+        "code": "LAS",
+        "name": "Lanao del Sur"
+      },
+      {
+        "code": "LEY",
+        "name": "Leyte"
+      },
+      {
+        "code": "MAG",
+        "name": "Maguindanao"
+      },
+      {
+        "code": "MAD",
+        "name": "Marinduque"
+      },
+      {
+        "code": "MAS",
+        "name": "Masbate"
+      },
+      {
+        "code": "MSC",
+        "name": "Misamis Occidental"
+      },
+      {
+        "code": "MSR",
+        "name": "Misamis Oriental"
+      },
+      {
+        "code": "MOU",
+        "name": "Mountain Province"
+      },
+      {
+        "code": "NEC",
+        "name": "Negros Occidental"
+      },
+      {
+        "code": "NER",
+        "name": "Negros Oriental"
+      },
+      {
+        "code": "NSA",
+        "name": "Northern Samar"
+      },
+      {
+        "code": "NUE",
+        "name": "Nueva Ecija"
+      },
+      {
+        "code": "NUV",
+        "name": "Nueva Vizcaya"
+      },
+      {
+        "code": "MDC",
+        "name": "Occidental Mindoro"
+      },
+      {
+        "code": "MDR",
+        "name": "Oriental Mindoro"
+      },
+      {
+        "code": "PLW",
+        "name": "Palawan"
+      },
+      {
+        "code": "PAM",
+        "name": "Pampanga"
+      },
+      {
+        "code": "PAN",
+        "name": "Pangasinan"
+      },
+      {
+        "code": "QUE",
+        "name": "Quezon"
+      },
+      {
+        "code": "QUI",
+        "name": "Quirino"
+      },
+      {
+        "code": "RIZ",
+        "name": "Rizal"
+      },
+      {
+        "code": "ROM",
+        "name": "Romblon"
+      },
+      {
+        "code": "WSA",
+        "name": "Samar"
+      },
+      {
+        "code": "SAR",
+        "name": "Sarangani"
+      },
+      {
+        "code": "SIQ",
+        "name": "Siquijor"
+      },
+      {
+        "code": "SOR",
+        "name": "Sorsogon"
+      },
+      {
+        "code": "SCO",
+        "name": "South Cotabato"
+      },
+      {
+        "code": "SLE",
+        "name": "Southern Leyte"
+      },
+      {
+        "code": "SUK",
+        "name": "Sultan Kudarat"
+      },
+      {
+        "code": "SLU",
+        "name": "Sulu"
+      },
+      {
+        "code": "SUN",
+        "name": "Surigao del Norte"
+      },
+      {
+        "code": "SUR",
+        "name": "Surigao del Sur"
+      },
+      {
+        "code": "TAR",
+        "name": "Tarlac"
+      },
+      {
+        "code": "TAW",
+        "name": "Tawi-Tawi"
+      },
+      {
+        "code": "ZMB",
+        "name": "Zambales"
+      },
+      {
+        "code": "ZAN",
+        "name": "Zamboanga del Norte"
+      },
+      {
+        "code": "ZAS",
+        "name": "Zamboanga del Sur"
+      },
+      {
+        "code": "ZSI",
+        "name": "Zamboanga Sibugay"
+      },
+      {
+        "code": "00",
+        "name": "Metro Manila"
+      }
+    ]
+  },
+  {
+    "code": "PN",
+    "name": "Pitcairn",
+    "states": []
+  },
+  {
+    "code": "PL",
+    "name": "Poland",
+    "states": []
+  },
+  {
+    "code": "PT",
+    "name": "Portugal",
+    "states": []
+  },
+  {
+    "code": "PR",
+    "name": "Puerto Rico",
+    "states": []
+  },
+  {
+    "code": "QA",
+    "name": "Qatar",
+    "states": []
+  },
+  {
+    "code": "RE",
+    "name": "Reunion",
+    "states": []
+  },
+  {
+    "code": "RO",
+    "name": "Romania",
+    "states": [
+      {
+        "code": "AB",
+        "name": "Alba"
+      },
+      {
+        "code": "AR",
+        "name": "Arad"
+      },
+      {
+        "code": "AG",
+        "name": "Argeș"
+      },
+      {
+        "code": "BC",
+        "name": "Bacău"
+      },
+      {
+        "code": "BH",
+        "name": "Bihor"
+      },
+      {
+        "code": "BN",
+        "name": "Bistrița-Năsăud"
+      },
+      {
+        "code": "BT",
+        "name": "Botoșani"
+      },
+      {
+        "code": "BR",
+        "name": "Brăila"
+      },
+      {
+        "code": "BV",
+        "name": "Brașov"
+      },
+      {
+        "code": "B",
+        "name": "București"
+      },
+      {
+        "code": "BZ",
+        "name": "Buzău"
+      },
+      {
+        "code": "CL",
+        "name": "Călărași"
+      },
+      {
+        "code": "CS",
+        "name": "Caraș-Severin"
+      },
+      {
+        "code": "CJ",
+        "name": "Cluj"
+      },
+      {
+        "code": "CT",
+        "name": "Constanța"
+      },
+      {
+        "code": "CV",
+        "name": "Covasna"
+      },
+      {
+        "code": "DB",
+        "name": "Dâmbovița"
+      },
+      {
+        "code": "DJ",
+        "name": "Dolj"
+      },
+      {
+        "code": "GL",
+        "name": "Galați"
+      },
+      {
+        "code": "GR",
+        "name": "Giurgiu"
+      },
+      {
+        "code": "GJ",
+        "name": "Gorj"
+      },
+      {
+        "code": "HR",
+        "name": "Harghita"
+      },
+      {
+        "code": "HD",
+        "name": "Hunedoara"
+      },
+      {
+        "code": "IL",
+        "name": "Ialomița"
+      },
+      {
+        "code": "IS",
+        "name": "Iași"
+      },
+      {
+        "code": "IF",
+        "name": "Ilfov"
+      },
+      {
+        "code": "MM",
+        "name": "Maramureș"
+      },
+      {
+        "code": "MH",
+        "name": "Mehedinți"
+      },
+      {
+        "code": "MS",
+        "name": "Mureș"
+      },
+      {
+        "code": "NT",
+        "name": "Neamț"
+      },
+      {
+        "code": "OT",
+        "name": "Olt"
+      },
+      {
+        "code": "PH",
+        "name": "Prahova"
+      },
+      {
+        "code": "SJ",
+        "name": "Sălaj"
+      },
+      {
+        "code": "SM",
+        "name": "Satu Mare"
+      },
+      {
+        "code": "SB",
+        "name": "Sibiu"
+      },
+      {
+        "code": "SV",
+        "name": "Suceava"
+      },
+      {
+        "code": "TR",
+        "name": "Teleorman"
+      },
+      {
+        "code": "TM",
+        "name": "Timiș"
+      },
+      {
+        "code": "TL",
+        "name": "Tulcea"
+      },
+      {
+        "code": "VL",
+        "name": "Vâlcea"
+      },
+      {
+        "code": "VS",
+        "name": "Vaslui"
+      },
+      {
+        "code": "VN",
+        "name": "Vrancea"
+      }
+    ]
+  },
+  {
+    "code": "RU",
+    "name": "Russia",
+    "states": []
+  },
+  {
+    "code": "RW",
+    "name": "Rwanda",
+    "states": []
+  },
+  {
+    "code": "ST",
+    "name": "S&atilde;o Tom&eacute; and Pr&iacute;ncipe",
+    "states": []
+  },
+  {
+    "code": "BL",
+    "name": "Saint Barth&eacute;lemy",
+    "states": []
+  },
+  {
+    "code": "SH",
+    "name": "Saint Helena",
+    "states": []
+  },
+  {
+    "code": "KN",
+    "name": "Saint Kitts and Nevis",
+    "states": []
+  },
+  {
+    "code": "LC",
+    "name": "Saint Lucia",
+    "states": []
+  },
+  {
+    "code": "SX",
+    "name": "Saint Martin (Dutch part)",
+    "states": []
+  },
+  {
+    "code": "MF",
+    "name": "Saint Martin (French part)",
+    "states": []
+  },
+  {
+    "code": "PM",
+    "name": "Saint Pierre and Miquelon",
+    "states": []
+  },
+  {
+    "code": "VC",
+    "name": "Saint Vincent and the Grenadines",
+    "states": []
+  },
+  {
+    "code": "WS",
+    "name": "Samoa",
+    "states": []
+  },
+  {
+    "code": "SM",
+    "name": "San Marino",
+    "states": []
+  },
+  {
+    "code": "SA",
+    "name": "Saudi Arabia",
+    "states": []
+  },
+  {
+    "code": "SN",
+    "name": "Senegal",
+    "states": [
+      {
+        "code": "SNDB",
+        "name": "Diourbel"
+      },
+      {
+        "code": "SNDK",
+        "name": "Dakar"
+      },
+      {
+        "code": "SNFK",
+        "name": "Fatick"
+      },
+      {
+        "code": "SNKA",
+        "name": "Kaffrine"
+      },
+      {
+        "code": "SNKD",
+        "name": "Kolda"
+      },
+      {
+        "code": "SNKE",
+        "name": "Kédougou"
+      },
+      {
+        "code": "SNKL",
+        "name": "Kaolack"
+      },
+      {
+        "code": "SNLG",
+        "name": "Louga"
+      },
+      {
+        "code": "SNMT",
+        "name": "Matam"
+      },
+      {
+        "code": "SNSE",
+        "name": "Sédhiou"
+      },
+      {
+        "code": "SNSL",
+        "name": "Saint-Louis"
+      },
+      {
+        "code": "SNTC",
+        "name": "Tambacounda"
+      },
+      {
+        "code": "SNTH",
+        "name": "Thiès"
+      },
+      {
+        "code": "SNZG",
+        "name": "Ziguinchor"
+      }
+    ]
+  },
+  {
+    "code": "RS",
+    "name": "Serbia",
+    "states": [
+      {
+        "code": "RS00",
+        "name": "Belgrade"
+      },
+      {
+        "code": "RS14",
+        "name": "Bor"
+      },
+      {
+        "code": "RS11",
+        "name": "Braničevo"
+      },
+      {
+        "code": "RS02",
+        "name": "Central Banat"
+      },
+      {
+        "code": "RS10",
+        "name": "Danube"
+      },
+      {
+        "code": "RS23",
+        "name": "Jablanica"
+      },
+      {
+        "code": "RS09",
+        "name": "Kolubara"
+      },
+      {
+        "code": "RS08",
+        "name": "Mačva"
+      },
+      {
+        "code": "RS17",
+        "name": "Morava"
+      },
+      {
+        "code": "RS20",
+        "name": "Nišava"
+      },
+      {
+        "code": "RS01",
+        "name": "North Bačka"
+      },
+      {
+        "code": "RS03",
+        "name": "North Banat"
+      },
+      {
+        "code": "RS24",
+        "name": "Pčinja"
+      },
+      {
+        "code": "RS22",
+        "name": "Pirot"
+      },
+      {
+        "code": "RS13",
+        "name": "Pomoravlje"
+      },
+      {
+        "code": "RS19",
+        "name": "Rasina"
+      },
+      {
+        "code": "RS18",
+        "name": "Raška"
+      },
+      {
+        "code": "RS06",
+        "name": "South Bačka"
+      },
+      {
+        "code": "RS04",
+        "name": "South Banat"
+      },
+      {
+        "code": "RS07",
+        "name": "Srem"
+      },
+      {
+        "code": "RS12",
+        "name": "Šumadija"
+      },
+      {
+        "code": "RS21",
+        "name": "Toplica"
+      },
+      {
+        "code": "RS05",
+        "name": "West Bačka"
+      },
+      {
+        "code": "RS15",
+        "name": "Zaječar"
+      },
+      {
+        "code": "RS16",
+        "name": "Zlatibor"
+      },
+      {
+        "code": "RS25",
+        "name": "Kosovo"
+      },
+      {
+        "code": "RS26",
+        "name": "Peć"
+      },
+      {
+        "code": "RS27",
+        "name": "Prizren"
+      },
+      {
+        "code": "RS28",
+        "name": "Kosovska Mitrovica"
+      },
+      {
+        "code": "RS29",
+        "name": "Kosovo-Pomoravlje"
+      },
+      {
+        "code": "RSKM",
+        "name": "Kosovo-Metohija"
+      },
+      {
+        "code": "RSVO",
+        "name": "Vojvodina"
+      }
+    ]
+  },
+  {
+    "code": "SC",
+    "name": "Seychelles",
+    "states": []
+  },
+  {
+    "code": "SL",
+    "name": "Sierra Leone",
+    "states": []
+  },
+  {
+    "code": "SG",
+    "name": "Singapore",
+    "states": []
+  },
+  {
+    "code": "SK",
+    "name": "Slovakia",
+    "states": []
+  },
+  {
+    "code": "SI",
+    "name": "Slovenia",
+    "states": []
+  },
+  {
+    "code": "SB",
+    "name": "Solomon Islands",
+    "states": []
+  },
+  {
+    "code": "SO",
+    "name": "Somalia",
+    "states": []
+  },
+  {
+    "code": "ZA",
+    "name": "South Africa",
+    "states": [
+      {
+        "code": "EC",
+        "name": "Eastern Cape"
+      },
+      {
+        "code": "FS",
+        "name": "Free State"
+      },
+      {
+        "code": "GP",
+        "name": "Gauteng"
+      },
+      {
+        "code": "KZN",
+        "name": "KwaZulu-Natal"
+      },
+      {
+        "code": "LP",
+        "name": "Limpopo"
+      },
+      {
+        "code": "MP",
+        "name": "Mpumalanga"
+      },
+      {
+        "code": "NC",
+        "name": "Northern Cape"
+      },
+      {
+        "code": "NW",
+        "name": "North West"
+      },
+      {
+        "code": "WC",
+        "name": "Western Cape"
+      }
+    ]
+  },
+  {
+    "code": "GS",
+    "name": "South Georgia/Sandwich Islands",
+    "states": []
+  },
+  {
+    "code": "KR",
+    "name": "South Korea",
+    "states": []
+  },
+  {
+    "code": "SS",
+    "name": "South Sudan",
+    "states": []
+  },
+  {
+    "code": "ES",
+    "name": "Spain",
+    "states": [
+      {
+        "code": "C",
+        "name": "A Coruña"
+      },
+      {
+        "code": "VI",
+        "name": "Araba/Álava"
+      },
+      {
+        "code": "AB",
+        "name": "Albacete"
+      },
+      {
+        "code": "A",
+        "name": "Alicante"
+      },
+      {
+        "code": "AL",
+        "name": "Almería"
+      },
+      {
+        "code": "O",
+        "name": "Asturias"
+      },
+      {
+        "code": "AV",
+        "name": "Ávila"
+      },
+      {
+        "code": "BA",
+        "name": "Badajoz"
+      },
+      {
+        "code": "PM",
+        "name": "Baleares"
+      },
+      {
+        "code": "B",
+        "name": "Barcelona"
+      },
+      {
+        "code": "BU",
+        "name": "Burgos"
+      },
+      {
+        "code": "CC",
+        "name": "Cáceres"
+      },
+      {
+        "code": "CA",
+        "name": "Cádiz"
+      },
+      {
+        "code": "S",
+        "name": "Cantabria"
+      },
+      {
+        "code": "CS",
+        "name": "Castellón"
+      },
+      {
+        "code": "CE",
+        "name": "Ceuta"
+      },
+      {
+        "code": "CR",
+        "name": "Ciudad Real"
+      },
+      {
+        "code": "CO",
+        "name": "Córdoba"
+      },
+      {
+        "code": "CU",
+        "name": "Cuenca"
+      },
+      {
+        "code": "GI",
+        "name": "Girona"
+      },
+      {
+        "code": "GR",
+        "name": "Granada"
+      },
+      {
+        "code": "GU",
+        "name": "Guadalajara"
+      },
+      {
+        "code": "SS",
+        "name": "Gipuzkoa"
+      },
+      {
+        "code": "H",
+        "name": "Huelva"
+      },
+      {
+        "code": "HU",
+        "name": "Huesca"
+      },
+      {
+        "code": "J",
+        "name": "Jaén"
+      },
+      {
+        "code": "LO",
+        "name": "La Rioja"
+      },
+      {
+        "code": "GC",
+        "name": "Las Palmas"
+      },
+      {
+        "code": "LE",
+        "name": "León"
+      },
+      {
+        "code": "L",
+        "name": "Lleida"
+      },
+      {
+        "code": "LU",
+        "name": "Lugo"
+      },
+      {
+        "code": "M",
+        "name": "Madrid"
+      },
+      {
+        "code": "MA",
+        "name": "Málaga"
+      },
+      {
+        "code": "ML",
+        "name": "Melilla"
+      },
+      {
+        "code": "MU",
+        "name": "Murcia"
+      },
+      {
+        "code": "NA",
+        "name": "Navarra"
+      },
+      {
+        "code": "OR",
+        "name": "Ourense"
+      },
+      {
+        "code": "P",
+        "name": "Palencia"
+      },
+      {
+        "code": "PO",
+        "name": "Pontevedra"
+      },
+      {
+        "code": "SA",
+        "name": "Salamanca"
+      },
+      {
+        "code": "TF",
+        "name": "Santa Cruz de Tenerife"
+      },
+      {
+        "code": "SG",
+        "name": "Segovia"
+      },
+      {
+        "code": "SE",
+        "name": "Sevilla"
+      },
+      {
+        "code": "SO",
+        "name": "Soria"
+      },
+      {
+        "code": "T",
+        "name": "Tarragona"
+      },
+      {
+        "code": "TE",
+        "name": "Teruel"
+      },
+      {
+        "code": "TO",
+        "name": "Toledo"
+      },
+      {
+        "code": "V",
+        "name": "Valencia"
+      },
+      {
+        "code": "VA",
+        "name": "Valladolid"
+      },
+      {
+        "code": "BI",
+        "name": "Biscay"
+      },
+      {
+        "code": "ZA",
+        "name": "Zamora"
+      },
+      {
+        "code": "Z",
+        "name": "Zaragoza"
+      }
+    ]
+  },
+  {
+    "code": "LK",
+    "name": "Sri Lanka",
+    "states": []
+  },
+  {
+    "code": "SD",
+    "name": "Sudan",
+    "states": []
+  },
+  {
+    "code": "SR",
+    "name": "Suriname",
+    "states": []
+  },
+  {
+    "code": "SJ",
+    "name": "Svalbard and Jan Mayen",
+    "states": []
+  },
+  {
+    "code": "SE",
+    "name": "Sweden",
+    "states": []
+  },
+  {
+    "code": "CH",
+    "name": "Switzerland",
+    "states": [
+      {
+        "code": "AG",
+        "name": "Aargau"
+      },
+      {
+        "code": "AR",
+        "name": "Appenzell Ausserrhoden"
+      },
+      {
+        "code": "AI",
+        "name": "Appenzell Innerrhoden"
+      },
+      {
+        "code": "BL",
+        "name": "Basel-Landschaft"
+      },
+      {
+        "code": "BS",
+        "name": "Basel-Stadt"
+      },
+      {
+        "code": "BE",
+        "name": "Bern"
+      },
+      {
+        "code": "FR",
+        "name": "Fribourg"
+      },
+      {
+        "code": "GE",
+        "name": "Geneva"
+      },
+      {
+        "code": "GL",
+        "name": "Glarus"
+      },
+      {
+        "code": "GR",
+        "name": "Graubünden"
+      },
+      {
+        "code": "JU",
+        "name": "Jura"
+      },
+      {
+        "code": "LU",
+        "name": "Luzern"
+      },
+      {
+        "code": "NE",
+        "name": "Neuchâtel"
+      },
+      {
+        "code": "NW",
+        "name": "Nidwalden"
+      },
+      {
+        "code": "OW",
+        "name": "Obwalden"
+      },
+      {
+        "code": "SH",
+        "name": "Schaffhausen"
+      },
+      {
+        "code": "SZ",
+        "name": "Schwyz"
+      },
+      {
+        "code": "SO",
+        "name": "Solothurn"
+      },
+      {
+        "code": "SG",
+        "name": "St. Gallen"
+      },
+      {
+        "code": "TG",
+        "name": "Thurgau"
+      },
+      {
+        "code": "TI",
+        "name": "Ticino"
+      },
+      {
+        "code": "UR",
+        "name": "Uri"
+      },
+      {
+        "code": "VS",
+        "name": "Valais"
+      },
+      {
+        "code": "VD",
+        "name": "Vaud"
+      },
+      {
+        "code": "ZG",
+        "name": "Zug"
+      },
+      {
+        "code": "ZH",
+        "name": "Zürich"
+      }
+    ]
+  },
+  {
+    "code": "SY",
+    "name": "Syria",
+    "states": []
+  },
+  {
+    "code": "TW",
+    "name": "Taiwan",
+    "states": []
+  },
+  {
+    "code": "TJ",
+    "name": "Tajikistan",
+    "states": []
+  },
+  {
+    "code": "TZ",
+    "name": "Tanzania",
+    "states": [
+      {
+        "code": "TZ01",
+        "name": "Arusha"
+      },
+      {
+        "code": "TZ02",
+        "name": "Dar es Salaam"
+      },
+      {
+        "code": "TZ03",
+        "name": "Dodoma"
+      },
+      {
+        "code": "TZ04",
+        "name": "Iringa"
+      },
+      {
+        "code": "TZ05",
+        "name": "Kagera"
+      },
+      {
+        "code": "TZ06",
+        "name": "Pemba North"
+      },
+      {
+        "code": "TZ07",
+        "name": "Zanzibar North"
+      },
+      {
+        "code": "TZ08",
+        "name": "Kigoma"
+      },
+      {
+        "code": "TZ09",
+        "name": "Kilimanjaro"
+      },
+      {
+        "code": "TZ10",
+        "name": "Pemba South"
+      },
+      {
+        "code": "TZ11",
+        "name": "Zanzibar South"
+      },
+      {
+        "code": "TZ12",
+        "name": "Lindi"
+      },
+      {
+        "code": "TZ13",
+        "name": "Mara"
+      },
+      {
+        "code": "TZ14",
+        "name": "Mbeya"
+      },
+      {
+        "code": "TZ15",
+        "name": "Zanzibar West"
+      },
+      {
+        "code": "TZ16",
+        "name": "Morogoro"
+      },
+      {
+        "code": "TZ17",
+        "name": "Mtwara"
+      },
+      {
+        "code": "TZ18",
+        "name": "Mwanza"
+      },
+      {
+        "code": "TZ19",
+        "name": "Coast"
+      },
+      {
+        "code": "TZ20",
+        "name": "Rukwa"
+      },
+      {
+        "code": "TZ21",
+        "name": "Ruvuma"
+      },
+      {
+        "code": "TZ22",
+        "name": "Shinyanga"
+      },
+      {
+        "code": "TZ23",
+        "name": "Singida"
+      },
+      {
+        "code": "TZ24",
+        "name": "Tabora"
+      },
+      {
+        "code": "TZ25",
+        "name": "Tanga"
+      },
+      {
+        "code": "TZ26",
+        "name": "Manyara"
+      },
+      {
+        "code": "TZ27",
+        "name": "Geita"
+      },
+      {
+        "code": "TZ28",
+        "name": "Katavi"
+      },
+      {
+        "code": "TZ29",
+        "name": "Njombe"
+      },
+      {
+        "code": "TZ30",
+        "name": "Simiyu"
+      }
+    ]
+  },
+  {
+    "code": "TH",
+    "name": "Thailand",
+    "states": [
+      {
+        "code": "TH-37",
+        "name": "Amnat Charoen"
+      },
+      {
+        "code": "TH-15",
+        "name": "Ang Thong"
+      },
+      {
+        "code": "TH-14",
+        "name": "Ayutthaya"
+      },
+      {
+        "code": "TH-10",
+        "name": "Bangkok"
+      },
+      {
+        "code": "TH-38",
+        "name": "Bueng Kan"
+      },
+      {
+        "code": "TH-31",
+        "name": "Buri Ram"
+      },
+      {
+        "code": "TH-24",
+        "name": "Chachoengsao"
+      },
+      {
+        "code": "TH-18",
+        "name": "Chai Nat"
+      },
+      {
+        "code": "TH-36",
+        "name": "Chaiyaphum"
+      },
+      {
+        "code": "TH-22",
+        "name": "Chanthaburi"
+      },
+      {
+        "code": "TH-50",
+        "name": "Chiang Mai"
+      },
+      {
+        "code": "TH-57",
+        "name": "Chiang Rai"
+      },
+      {
+        "code": "TH-20",
+        "name": "Chonburi"
+      },
+      {
+        "code": "TH-86",
+        "name": "Chumphon"
+      },
+      {
+        "code": "TH-46",
+        "name": "Kalasin"
+      },
+      {
+        "code": "TH-62",
+        "name": "Kamphaeng Phet"
+      },
+      {
+        "code": "TH-71",
+        "name": "Kanchanaburi"
+      },
+      {
+        "code": "TH-40",
+        "name": "Khon Kaen"
+      },
+      {
+        "code": "TH-81",
+        "name": "Krabi"
+      },
+      {
+        "code": "TH-52",
+        "name": "Lampang"
+      },
+      {
+        "code": "TH-51",
+        "name": "Lamphun"
+      },
+      {
+        "code": "TH-42",
+        "name": "Loei"
+      },
+      {
+        "code": "TH-16",
+        "name": "Lopburi"
+      },
+      {
+        "code": "TH-58",
+        "name": "Mae Hong Son"
+      },
+      {
+        "code": "TH-44",
+        "name": "Maha Sarakham"
+      },
+      {
+        "code": "TH-49",
+        "name": "Mukdahan"
+      },
+      {
+        "code": "TH-26",
+        "name": "Nakhon Nayok"
+      },
+      {
+        "code": "TH-73",
+        "name": "Nakhon Pathom"
+      },
+      {
+        "code": "TH-48",
+        "name": "Nakhon Phanom"
+      },
+      {
+        "code": "TH-30",
+        "name": "Nakhon Ratchasima"
+      },
+      {
+        "code": "TH-60",
+        "name": "Nakhon Sawan"
+      },
+      {
+        "code": "TH-80",
+        "name": "Nakhon Si Thammarat"
+      },
+      {
+        "code": "TH-55",
+        "name": "Nan"
+      },
+      {
+        "code": "TH-96",
+        "name": "Narathiwat"
+      },
+      {
+        "code": "TH-39",
+        "name": "Nong Bua Lam Phu"
+      },
+      {
+        "code": "TH-43",
+        "name": "Nong Khai"
+      },
+      {
+        "code": "TH-12",
+        "name": "Nonthaburi"
+      },
+      {
+        "code": "TH-13",
+        "name": "Pathum Thani"
+      },
+      {
+        "code": "TH-94",
+        "name": "Pattani"
+      },
+      {
+        "code": "TH-82",
+        "name": "Phang Nga"
+      },
+      {
+        "code": "TH-93",
+        "name": "Phatthalung"
+      },
+      {
+        "code": "TH-56",
+        "name": "Phayao"
+      },
+      {
+        "code": "TH-67",
+        "name": "Phetchabun"
+      },
+      {
+        "code": "TH-76",
+        "name": "Phetchaburi"
+      },
+      {
+        "code": "TH-66",
+        "name": "Phichit"
+      },
+      {
+        "code": "TH-65",
+        "name": "Phitsanulok"
+      },
+      {
+        "code": "TH-54",
+        "name": "Phrae"
+      },
+      {
+        "code": "TH-83",
+        "name": "Phuket"
+      },
+      {
+        "code": "TH-25",
+        "name": "Prachin Buri"
+      },
+      {
+        "code": "TH-77",
+        "name": "Prachuap Khiri Khan"
+      },
+      {
+        "code": "TH-85",
+        "name": "Ranong"
+      },
+      {
+        "code": "TH-70",
+        "name": "Ratchaburi"
+      },
+      {
+        "code": "TH-21",
+        "name": "Rayong"
+      },
+      {
+        "code": "TH-45",
+        "name": "Roi Et"
+      },
+      {
+        "code": "TH-27",
+        "name": "Sa Kaeo"
+      },
+      {
+        "code": "TH-47",
+        "name": "Sakon Nakhon"
+      },
+      {
+        "code": "TH-11",
+        "name": "Samut Prakan"
+      },
+      {
+        "code": "TH-74",
+        "name": "Samut Sakhon"
+      },
+      {
+        "code": "TH-75",
+        "name": "Samut Songkhram"
+      },
+      {
+        "code": "TH-19",
+        "name": "Saraburi"
+      },
+      {
+        "code": "TH-91",
+        "name": "Satun"
+      },
+      {
+        "code": "TH-17",
+        "name": "Sing Buri"
+      },
+      {
+        "code": "TH-33",
+        "name": "Sisaket"
+      },
+      {
+        "code": "TH-90",
+        "name": "Songkhla"
+      },
+      {
+        "code": "TH-64",
+        "name": "Sukhothai"
+      },
+      {
+        "code": "TH-72",
+        "name": "Suphan Buri"
+      },
+      {
+        "code": "TH-84",
+        "name": "Surat Thani"
+      },
+      {
+        "code": "TH-32",
+        "name": "Surin"
+      },
+      {
+        "code": "TH-63",
+        "name": "Tak"
+      },
+      {
+        "code": "TH-92",
+        "name": "Trang"
+      },
+      {
+        "code": "TH-23",
+        "name": "Trat"
+      },
+      {
+        "code": "TH-34",
+        "name": "Ubon Ratchathani"
+      },
+      {
+        "code": "TH-41",
+        "name": "Udon Thani"
+      },
+      {
+        "code": "TH-61",
+        "name": "Uthai Thani"
+      },
+      {
+        "code": "TH-53",
+        "name": "Uttaradit"
+      },
+      {
+        "code": "TH-95",
+        "name": "Yala"
+      },
+      {
+        "code": "TH-35",
+        "name": "Yasothon"
+      }
+    ]
+  },
+  {
+    "code": "TL",
+    "name": "Timor-Leste",
+    "states": []
+  },
+  {
+    "code": "TG",
+    "name": "Togo",
+    "states": []
+  },
+  {
+    "code": "TK",
+    "name": "Tokelau",
+    "states": []
+  },
+  {
+    "code": "TO",
+    "name": "Tonga",
+    "states": []
+  },
+  {
+    "code": "TT",
+    "name": "Trinidad and Tobago",
+    "states": []
+  },
+  {
+    "code": "TN",
+    "name": "Tunisia",
+    "states": []
+  },
+  {
+    "code": "TR",
+    "name": "Turkey",
+    "states": [
+      {
+        "code": "TR01",
+        "name": "Adana"
+      },
+      {
+        "code": "TR02",
+        "name": "Adıyaman"
+      },
+      {
+        "code": "TR03",
+        "name": "Afyon"
+      },
+      {
+        "code": "TR04",
+        "name": "Ağrı"
+      },
+      {
+        "code": "TR05",
+        "name": "Amasya"
+      },
+      {
+        "code": "TR06",
+        "name": "Ankara"
+      },
+      {
+        "code": "TR07",
+        "name": "Antalya"
+      },
+      {
+        "code": "TR08",
+        "name": "Artvin"
+      },
+      {
+        "code": "TR09",
+        "name": "Aydın"
+      },
+      {
+        "code": "TR10",
+        "name": "Balıkesir"
+      },
+      {
+        "code": "TR11",
+        "name": "Bilecik"
+      },
+      {
+        "code": "TR12",
+        "name": "Bingöl"
+      },
+      {
+        "code": "TR13",
+        "name": "Bitlis"
+      },
+      {
+        "code": "TR14",
+        "name": "Bolu"
+      },
+      {
+        "code": "TR15",
+        "name": "Burdur"
+      },
+      {
+        "code": "TR16",
+        "name": "Bursa"
+      },
+      {
+        "code": "TR17",
+        "name": "Çanakkale"
+      },
+      {
+        "code": "TR18",
+        "name": "Çankırı"
+      },
+      {
+        "code": "TR19",
+        "name": "Çorum"
+      },
+      {
+        "code": "TR20",
+        "name": "Denizli"
+      },
+      {
+        "code": "TR21",
+        "name": "Diyarbakır"
+      },
+      {
+        "code": "TR22",
+        "name": "Edirne"
+      },
+      {
+        "code": "TR23",
+        "name": "Elazığ"
+      },
+      {
+        "code": "TR24",
+        "name": "Erzincan"
+      },
+      {
+        "code": "TR25",
+        "name": "Erzurum"
+      },
+      {
+        "code": "TR26",
+        "name": "Eskişehir"
+      },
+      {
+        "code": "TR27",
+        "name": "Gaziantep"
+      },
+      {
+        "code": "TR28",
+        "name": "Giresun"
+      },
+      {
+        "code": "TR29",
+        "name": "Gümüşhane"
+      },
+      {
+        "code": "TR30",
+        "name": "Hakkari"
+      },
+      {
+        "code": "TR31",
+        "name": "Hatay"
+      },
+      {
+        "code": "TR32",
+        "name": "Isparta"
+      },
+      {
+        "code": "TR33",
+        "name": "İçel"
+      },
+      {
+        "code": "TR34",
+        "name": "İstanbul"
+      },
+      {
+        "code": "TR35",
+        "name": "İzmir"
+      },
+      {
+        "code": "TR36",
+        "name": "Kars"
+      },
+      {
+        "code": "TR37",
+        "name": "Kastamonu"
+      },
+      {
+        "code": "TR38",
+        "name": "Kayseri"
+      },
+      {
+        "code": "TR39",
+        "name": "Kırklareli"
+      },
+      {
+        "code": "TR40",
+        "name": "Kırşehir"
+      },
+      {
+        "code": "TR41",
+        "name": "Kocaeli"
+      },
+      {
+        "code": "TR42",
+        "name": "Konya"
+      },
+      {
+        "code": "TR43",
+        "name": "Kütahya"
+      },
+      {
+        "code": "TR44",
+        "name": "Malatya"
+      },
+      {
+        "code": "TR45",
+        "name": "Manisa"
+      },
+      {
+        "code": "TR46",
+        "name": "Kahramanmaraş"
+      },
+      {
+        "code": "TR47",
+        "name": "Mardin"
+      },
+      {
+        "code": "TR48",
+        "name": "Muğla"
+      },
+      {
+        "code": "TR49",
+        "name": "Muş"
+      },
+      {
+        "code": "TR50",
+        "name": "Nevşehir"
+      },
+      {
+        "code": "TR51",
+        "name": "Niğde"
+      },
+      {
+        "code": "TR52",
+        "name": "Ordu"
+      },
+      {
+        "code": "TR53",
+        "name": "Rize"
+      },
+      {
+        "code": "TR54",
+        "name": "Sakarya"
+      },
+      {
+        "code": "TR55",
+        "name": "Samsun"
+      },
+      {
+        "code": "TR56",
+        "name": "Siirt"
+      },
+      {
+        "code": "TR57",
+        "name": "Sinop"
+      },
+      {
+        "code": "TR58",
+        "name": "Sivas"
+      },
+      {
+        "code": "TR59",
+        "name": "Tekirdağ"
+      },
+      {
+        "code": "TR60",
+        "name": "Tokat"
+      },
+      {
+        "code": "TR61",
+        "name": "Trabzon"
+      },
+      {
+        "code": "TR62",
+        "name": "Tunceli"
+      },
+      {
+        "code": "TR63",
+        "name": "Şanlıurfa"
+      },
+      {
+        "code": "TR64",
+        "name": "Uşak"
+      },
+      {
+        "code": "TR65",
+        "name": "Van"
+      },
+      {
+        "code": "TR66",
+        "name": "Yozgat"
+      },
+      {
+        "code": "TR67",
+        "name": "Zonguldak"
+      },
+      {
+        "code": "TR68",
+        "name": "Aksaray"
+      },
+      {
+        "code": "TR69",
+        "name": "Bayburt"
+      },
+      {
+        "code": "TR70",
+        "name": "Karaman"
+      },
+      {
+        "code": "TR71",
+        "name": "Kırıkkale"
+      },
+      {
+        "code": "TR72",
+        "name": "Batman"
+      },
+      {
+        "code": "TR73",
+        "name": "Şırnak"
+      },
+      {
+        "code": "TR74",
+        "name": "Bartın"
+      },
+      {
+        "code": "TR75",
+        "name": "Ardahan"
+      },
+      {
+        "code": "TR76",
+        "name": "Iğdır"
+      },
+      {
+        "code": "TR77",
+        "name": "Yalova"
+      },
+      {
+        "code": "TR78",
+        "name": "Karabük"
+      },
+      {
+        "code": "TR79",
+        "name": "Kilis"
+      },
+      {
+        "code": "TR80",
+        "name": "Osmaniye"
+      },
+      {
+        "code": "TR81",
+        "name": "Düzce"
+      }
+    ]
+  },
+  {
+    "code": "TM",
+    "name": "Turkmenistan",
+    "states": []
+  },
+  {
+    "code": "TC",
+    "name": "Turks and Caicos Islands",
+    "states": []
+  },
+  {
+    "code": "TV",
+    "name": "Tuvalu",
+    "states": []
+  },
+  {
+    "code": "UG",
+    "name": "Uganda",
+    "states": [
+      {
+        "code": "UG314",
+        "name": "Abim"
+      },
+      {
+        "code": "UG301",
+        "name": "Adjumani"
+      },
+      {
+        "code": "UG322",
+        "name": "Agago"
+      },
+      {
+        "code": "UG323",
+        "name": "Alebtong"
+      },
+      {
+        "code": "UG315",
+        "name": "Amolatar"
+      },
+      {
+        "code": "UG324",
+        "name": "Amudat"
+      },
+      {
+        "code": "UG216",
+        "name": "Amuria"
+      },
+      {
+        "code": "UG316",
+        "name": "Amuru"
+      },
+      {
+        "code": "UG302",
+        "name": "Apac"
+      },
+      {
+        "code": "UG303",
+        "name": "Arua"
+      },
+      {
+        "code": "UG217",
+        "name": "Budaka"
+      },
+      {
+        "code": "UG218",
+        "name": "Bududa"
+      },
+      {
+        "code": "UG201",
+        "name": "Bugiri"
+      },
+      {
+        "code": "UG235",
+        "name": "Bugweri"
+      },
+      {
+        "code": "UG420",
+        "name": "Buhweju"
+      },
+      {
+        "code": "UG117",
+        "name": "Buikwe"
+      },
+      {
+        "code": "UG219",
+        "name": "Bukedea"
+      },
+      {
+        "code": "UG118",
+        "name": "Bukomansimbi"
+      },
+      {
+        "code": "UG220",
+        "name": "Bukwa"
+      },
+      {
+        "code": "UG225",
+        "name": "Bulambuli"
+      },
+      {
+        "code": "UG416",
+        "name": "Buliisa"
+      },
+      {
+        "code": "UG401",
+        "name": "Bundibugyo"
+      },
+      {
+        "code": "UG430",
+        "name": "Bunyangabu"
+      },
+      {
+        "code": "UG402",
+        "name": "Bushenyi"
+      },
+      {
+        "code": "UG202",
+        "name": "Busia"
+      },
+      {
+        "code": "UG221",
+        "name": "Butaleja"
+      },
+      {
+        "code": "UG119",
+        "name": "Butambala"
+      },
+      {
+        "code": "UG233",
+        "name": "Butebo"
+      },
+      {
+        "code": "UG120",
+        "name": "Buvuma"
+      },
+      {
+        "code": "UG226",
+        "name": "Buyende"
+      },
+      {
+        "code": "UG317",
+        "name": "Dokolo"
+      },
+      {
+        "code": "UG121",
+        "name": "Gomba"
+      },
+      {
+        "code": "UG304",
+        "name": "Gulu"
+      },
+      {
+        "code": "UG403",
+        "name": "Hoima"
+      },
+      {
+        "code": "UG417",
+        "name": "Ibanda"
+      },
+      {
+        "code": "UG203",
+        "name": "Iganga"
+      },
+      {
+        "code": "UG418",
+        "name": "Isingiro"
+      },
+      {
+        "code": "UG204",
+        "name": "Jinja"
+      },
+      {
+        "code": "UG318",
+        "name": "Kaabong"
+      },
+      {
+        "code": "UG404",
+        "name": "Kabale"
+      },
+      {
+        "code": "UG405",
+        "name": "Kabarole"
+      },
+      {
+        "code": "UG213",
+        "name": "Kaberamaido"
+      },
+      {
+        "code": "UG427",
+        "name": "Kagadi"
+      },
+      {
+        "code": "UG428",
+        "name": "Kakumiro"
+      },
+      {
+        "code": "UG101",
+        "name": "Kalangala"
+      },
+      {
+        "code": "UG222",
+        "name": "Kaliro"
+      },
+      {
+        "code": "UG122",
+        "name": "Kalungu"
+      },
+      {
+        "code": "UG102",
+        "name": "Kampala"
+      },
+      {
+        "code": "UG205",
+        "name": "Kamuli"
+      },
+      {
+        "code": "UG413",
+        "name": "Kamwenge"
+      },
+      {
+        "code": "UG414",
+        "name": "Kanungu"
+      },
+      {
+        "code": "UG206",
+        "name": "Kapchorwa"
+      },
+      {
+        "code": "UG236",
+        "name": "Kapelebyong"
+      },
+      {
+        "code": "UG126",
+        "name": "Kasanda"
+      },
+      {
+        "code": "UG406",
+        "name": "Kasese"
+      },
+      {
+        "code": "UG207",
+        "name": "Katakwi"
+      },
+      {
+        "code": "UG112",
+        "name": "Kayunga"
+      },
+      {
+        "code": "UG407",
+        "name": "Kibaale"
+      },
+      {
+        "code": "UG103",
+        "name": "Kiboga"
+      },
+      {
+        "code": "UG227",
+        "name": "Kibuku"
+      },
+      {
+        "code": "UG432",
+        "name": "Kikuube"
+      },
+      {
+        "code": "UG419",
+        "name": "Kiruhura"
+      },
+      {
+        "code": "UG421",
+        "name": "Kiryandongo"
+      },
+      {
+        "code": "UG408",
+        "name": "Kisoro"
+      },
+      {
+        "code": "UG305",
+        "name": "Kitgum"
+      },
+      {
+        "code": "UG319",
+        "name": "Koboko"
+      },
+      {
+        "code": "UG325",
+        "name": "Kole"
+      },
+      {
+        "code": "UG306",
+        "name": "Kotido"
+      },
+      {
+        "code": "UG208",
+        "name": "Kumi"
+      },
+      {
+        "code": "UG333",
+        "name": "Kwania"
+      },
+      {
+        "code": "UG228",
+        "name": "Kween"
+      },
+      {
+        "code": "UG123",
+        "name": "Kyankwanzi"
+      },
+      {
+        "code": "UG422",
+        "name": "Kyegegwa"
+      },
+      {
+        "code": "UG415",
+        "name": "Kyenjojo"
+      },
+      {
+        "code": "UG125",
+        "name": "Kyotera"
+      },
+      {
+        "code": "UG326",
+        "name": "Lamwo"
+      },
+      {
+        "code": "UG307",
+        "name": "Lira"
+      },
+      {
+        "code": "UG229",
+        "name": "Luuka"
+      },
+      {
+        "code": "UG104",
+        "name": "Luwero"
+      },
+      {
+        "code": "UG124",
+        "name": "Lwengo"
+      },
+      {
+        "code": "UG114",
+        "name": "Lyantonde"
+      },
+      {
+        "code": "UG223",
+        "name": "Manafwa"
+      },
+      {
+        "code": "UG320",
+        "name": "Maracha"
+      },
+      {
+        "code": "UG105",
+        "name": "Masaka"
+      },
+      {
+        "code": "UG409",
+        "name": "Masindi"
+      },
+      {
+        "code": "UG214",
+        "name": "Mayuge"
+      },
+      {
+        "code": "UG209",
+        "name": "Mbale"
+      },
+      {
+        "code": "UG410",
+        "name": "Mbarara"
+      },
+      {
+        "code": "UG423",
+        "name": "Mitooma"
+      },
+      {
+        "code": "UG115",
+        "name": "Mityana"
+      },
+      {
+        "code": "UG308",
+        "name": "Moroto"
+      },
+      {
+        "code": "UG309",
+        "name": "Moyo"
+      },
+      {
+        "code": "UG106",
+        "name": "Mpigi"
+      },
+      {
+        "code": "UG107",
+        "name": "Mubende"
+      },
+      {
+        "code": "UG108",
+        "name": "Mukono"
+      },
+      {
+        "code": "UG334",
+        "name": "Nabilatuk"
+      },
+      {
+        "code": "UG311",
+        "name": "Nakapiripirit"
+      },
+      {
+        "code": "UG116",
+        "name": "Nakaseke"
+      },
+      {
+        "code": "UG109",
+        "name": "Nakasongola"
+      },
+      {
+        "code": "UG230",
+        "name": "Namayingo"
+      },
+      {
+        "code": "UG234",
+        "name": "Namisindwa"
+      },
+      {
+        "code": "UG224",
+        "name": "Namutumba"
+      },
+      {
+        "code": "UG327",
+        "name": "Napak"
+      },
+      {
+        "code": "UG310",
+        "name": "Nebbi"
+      },
+      {
+        "code": "UG231",
+        "name": "Ngora"
+      },
+      {
+        "code": "UG424",
+        "name": "Ntoroko"
+      },
+      {
+        "code": "UG411",
+        "name": "Ntungamo"
+      },
+      {
+        "code": "UG328",
+        "name": "Nwoya"
+      },
+      {
+        "code": "UG331",
+        "name": "Omoro"
+      },
+      {
+        "code": "UG329",
+        "name": "Otuke"
+      },
+      {
+        "code": "UG321",
+        "name": "Oyam"
+      },
+      {
+        "code": "UG312",
+        "name": "Pader"
+      },
+      {
+        "code": "UG332",
+        "name": "Pakwach"
+      },
+      {
+        "code": "UG210",
+        "name": "Pallisa"
+      },
+      {
+        "code": "UG110",
+        "name": "Rakai"
+      },
+      {
+        "code": "UG429",
+        "name": "Rubanda"
+      },
+      {
+        "code": "UG425",
+        "name": "Rubirizi"
+      },
+      {
+        "code": "UG431",
+        "name": "Rukiga"
+      },
+      {
+        "code": "UG412",
+        "name": "Rukungiri"
+      },
+      {
+        "code": "UG111",
+        "name": "Sembabule"
+      },
+      {
+        "code": "UG232",
+        "name": "Serere"
+      },
+      {
+        "code": "UG426",
+        "name": "Sheema"
+      },
+      {
+        "code": "UG215",
+        "name": "Sironko"
+      },
+      {
+        "code": "UG211",
+        "name": "Soroti"
+      },
+      {
+        "code": "UG212",
+        "name": "Tororo"
+      },
+      {
+        "code": "UG113",
+        "name": "Wakiso"
+      },
+      {
+        "code": "UG313",
+        "name": "Yumbe"
+      },
+      {
+        "code": "UG330",
+        "name": "Zombo"
+      }
+    ]
+  },
+  {
+    "code": "UA",
+    "name": "Ukraine",
+    "states": [
+      {
+        "code": "UA05",
+        "name": "Vinnychchyna"
+      },
+      {
+        "code": "UA07",
+        "name": "Volyn"
+      },
+      {
+        "code": "UA09",
+        "name": "Luhanshchyna"
+      },
+      {
+        "code": "UA12",
+        "name": "Dnipropetrovshchyna"
+      },
+      {
+        "code": "UA14",
+        "name": "Donechchyna"
+      },
+      {
+        "code": "UA18",
+        "name": "Zhytomyrshchyna"
+      },
+      {
+        "code": "UA21",
+        "name": "Zakarpattia"
+      },
+      {
+        "code": "UA23",
+        "name": "Zaporizhzhya"
+      },
+      {
+        "code": "UA26",
+        "name": "Prykarpattia"
+      },
+      {
+        "code": "UA30",
+        "name": "Kyiv"
+      },
+      {
+        "code": "UA32",
+        "name": "Kyivshchyna"
+      },
+      {
+        "code": "UA35",
+        "name": "Kirovohradschyna"
+      },
+      {
+        "code": "UA40",
+        "name": "Sevastopol"
+      },
+      {
+        "code": "UA43",
+        "name": "Crimea"
+      },
+      {
+        "code": "UA46",
+        "name": "Lvivshchyna"
+      },
+      {
+        "code": "UA48",
+        "name": "Mykolayivschyna"
+      },
+      {
+        "code": "UA51",
+        "name": "Odeshchyna"
+      },
+      {
+        "code": "UA53",
+        "name": "Poltavshchyna"
+      },
+      {
+        "code": "UA56",
+        "name": "Rivnenshchyna"
+      },
+      {
+        "code": "UA59",
+        "name": "Sumshchyna"
+      },
+      {
+        "code": "UA61",
+        "name": "Ternopilshchyna"
+      },
+      {
+        "code": "UA63",
+        "name": "Kharkivshchyna"
+      },
+      {
+        "code": "UA65",
+        "name": "Khersonshchyna"
+      },
+      {
+        "code": "UA68",
+        "name": "Khmelnychchyna"
+      },
+      {
+        "code": "UA71",
+        "name": "Cherkashchyna"
+      },
+      {
+        "code": "UA74",
+        "name": "Chernihivshchyna"
+      },
+      {
+        "code": "UA77",
+        "name": "Chernivtsi Oblast"
+      }
+    ]
+  },
+  {
+    "code": "AE",
+    "name": "United Arab Emirates",
+    "states": []
+  },
+  {
+    "code": "GB",
+    "name": "United Kingdom (UK)",
+    "states": []
+  },
+  {
+    "code": "US",
+    "name": "United States (US)",
+    "states": [
+      {
+        "code": "AL",
+        "name": "Alabama"
+      },
+      {
+        "code": "AK",
+        "name": "Alaska"
+      },
+      {
+        "code": "AZ",
+        "name": "Arizona"
+      },
+      {
+        "code": "AR",
+        "name": "Arkansas"
+      },
+      {
+        "code": "CA",
+        "name": "California"
+      },
+      {
+        "code": "CO",
+        "name": "Colorado"
+      },
+      {
+        "code": "CT",
+        "name": "Connecticut"
+      },
+      {
+        "code": "DE",
+        "name": "Delaware"
+      },
+      {
+        "code": "DC",
+        "name": "District Of Columbia"
+      },
+      {
+        "code": "FL",
+        "name": "Florida"
+      },
+      {
+        "code": "GA",
+        "name": "Georgia"
+      },
+      {
+        "code": "HI",
+        "name": "Hawaii"
+      },
+      {
+        "code": "ID",
+        "name": "Idaho"
+      },
+      {
+        "code": "IL",
+        "name": "Illinois"
+      },
+      {
+        "code": "IN",
+        "name": "Indiana"
+      },
+      {
+        "code": "IA",
+        "name": "Iowa"
+      },
+      {
+        "code": "KS",
+        "name": "Kansas"
+      },
+      {
+        "code": "KY",
+        "name": "Kentucky"
+      },
+      {
+        "code": "LA",
+        "name": "Louisiana"
+      },
+      {
+        "code": "ME",
+        "name": "Maine"
+      },
+      {
+        "code": "MD",
+        "name": "Maryland"
+      },
+      {
+        "code": "MA",
+        "name": "Massachusetts"
+      },
+      {
+        "code": "MI",
+        "name": "Michigan"
+      },
+      {
+        "code": "MN",
+        "name": "Minnesota"
+      },
+      {
+        "code": "MS",
+        "name": "Mississippi"
+      },
+      {
+        "code": "MO",
+        "name": "Missouri"
+      },
+      {
+        "code": "MT",
+        "name": "Montana"
+      },
+      {
+        "code": "NE",
+        "name": "Nebraska"
+      },
+      {
+        "code": "NV",
+        "name": "Nevada"
+      },
+      {
+        "code": "NH",
+        "name": "New Hampshire"
+      },
+      {
+        "code": "NJ",
+        "name": "New Jersey"
+      },
+      {
+        "code": "NM",
+        "name": "New Mexico"
+      },
+      {
+        "code": "NY",
+        "name": "New York"
+      },
+      {
+        "code": "NC",
+        "name": "North Carolina"
+      },
+      {
+        "code": "ND",
+        "name": "North Dakota"
+      },
+      {
+        "code": "OH",
+        "name": "Ohio"
+      },
+      {
+        "code": "OK",
+        "name": "Oklahoma"
+      },
+      {
+        "code": "OR",
+        "name": "Oregon"
+      },
+      {
+        "code": "PA",
+        "name": "Pennsylvania"
+      },
+      {
+        "code": "RI",
+        "name": "Rhode Island"
+      },
+      {
+        "code": "SC",
+        "name": "South Carolina"
+      },
+      {
+        "code": "SD",
+        "name": "South Dakota"
+      },
+      {
+        "code": "TN",
+        "name": "Tennessee"
+      },
+      {
+        "code": "TX",
+        "name": "Texas"
+      },
+      {
+        "code": "UT",
+        "name": "Utah"
+      },
+      {
+        "code": "VT",
+        "name": "Vermont"
+      },
+      {
+        "code": "VA",
+        "name": "Virginia"
+      },
+      {
+        "code": "WA",
+        "name": "Washington"
+      },
+      {
+        "code": "WV",
+        "name": "West Virginia"
+      },
+      {
+        "code": "WI",
+        "name": "Wisconsin"
+      },
+      {
+        "code": "WY",
+        "name": "Wyoming"
+      },
+      {
+        "code": "AA",
+        "name": "Armed Forces (AA)"
+      },
+      {
+        "code": "AE",
+        "name": "Armed Forces (AE)"
+      },
+      {
+        "code": "AP",
+        "name": "Armed Forces (AP)"
+      }
+    ]
+  },
+  {
+    "code": "UM",
+    "name": "United States (US) Minor Outlying Islands",
+    "states": [
+      {
+        "code": 81,
+        "name": "Baker Island"
+      },
+      {
+        "code": 84,
+        "name": "Howland Island"
+      },
+      {
+        "code": 86,
+        "name": "Jarvis Island"
+      },
+      {
+        "code": 67,
+        "name": "Johnston Atoll"
+      },
+      {
+        "code": 89,
+        "name": "Kingman Reef"
+      },
+      {
+        "code": 71,
+        "name": "Midway Atoll"
+      },
+      {
+        "code": 76,
+        "name": "Navassa Island"
+      },
+      {
+        "code": 95,
+        "name": "Palmyra Atoll"
+      },
+      {
+        "code": 79,
+        "name": "Wake Island"
+      }
+    ]
+  },
+  {
+    "code": "UY",
+    "name": "Uruguay",
+    "states": [
+      {
+        "code": "UY-AR",
+        "name": "Artigas"
+      },
+      {
+        "code": "UY-CA",
+        "name": "Canelones"
+      },
+      {
+        "code": "UY-CL",
+        "name": "Cerro Largo"
+      },
+      {
+        "code": "UY-CO",
+        "name": "Colonia"
+      },
+      {
+        "code": "UY-DU",
+        "name": "Durazno"
+      },
+      {
+        "code": "UY-FS",
+        "name": "Flores"
+      },
+      {
+        "code": "UY-FD",
+        "name": "Florida"
+      },
+      {
+        "code": "UY-LA",
+        "name": "Lavalleja"
+      },
+      {
+        "code": "UY-MA",
+        "name": "Maldonado"
+      },
+      {
+        "code": "UY-MO",
+        "name": "Montevideo"
+      },
+      {
+        "code": "UY-PA",
+        "name": "Paysandú"
+      },
+      {
+        "code": "UY-RN",
+        "name": "Río Negro"
+      },
+      {
+        "code": "UY-RV",
+        "name": "Rivera"
+      },
+      {
+        "code": "UY-RO",
+        "name": "Rocha"
+      },
+      {
+        "code": "UY-SA",
+        "name": "Salto"
+      },
+      {
+        "code": "UY-SJ",
+        "name": "San José"
+      },
+      {
+        "code": "UY-SO",
+        "name": "Soriano"
+      },
+      {
+        "code": "UY-TA",
+        "name": "Tacuarembó"
+      },
+      {
+        "code": "UY-TT",
+        "name": "Treinta y Tres"
+      }
+    ]
+  },
+  {
+    "code": "UZ",
+    "name": "Uzbekistan",
+    "states": []
+  },
+  {
+    "code": "VU",
+    "name": "Vanuatu",
+    "states": []
+  },
+  {
+    "code": "VA",
+    "name": "Vatican",
+    "states": []
+  },
+  {
+    "code": "VE",
+    "name": "Venezuela",
+    "states": [
+      {
+        "code": "VE-A",
+        "name": "Capital"
+      },
+      {
+        "code": "VE-B",
+        "name": "Anzoátegui"
+      },
+      {
+        "code": "VE-C",
+        "name": "Apure"
+      },
+      {
+        "code": "VE-D",
+        "name": "Aragua"
+      },
+      {
+        "code": "VE-E",
+        "name": "Barinas"
+      },
+      {
+        "code": "VE-F",
+        "name": "Bolívar"
+      },
+      {
+        "code": "VE-G",
+        "name": "Carabobo"
+      },
+      {
+        "code": "VE-H",
+        "name": "Cojedes"
+      },
+      {
+        "code": "VE-I",
+        "name": "Falcón"
+      },
+      {
+        "code": "VE-J",
+        "name": "Guárico"
+      },
+      {
+        "code": "VE-K",
+        "name": "Lara"
+      },
+      {
+        "code": "VE-L",
+        "name": "Mérida"
+      },
+      {
+        "code": "VE-M",
+        "name": "Miranda"
+      },
+      {
+        "code": "VE-N",
+        "name": "Monagas"
+      },
+      {
+        "code": "VE-O",
+        "name": "Nueva Esparta"
+      },
+      {
+        "code": "VE-P",
+        "name": "Portuguesa"
+      },
+      {
+        "code": "VE-R",
+        "name": "Sucre"
+      },
+      {
+        "code": "VE-S",
+        "name": "Táchira"
+      },
+      {
+        "code": "VE-T",
+        "name": "Trujillo"
+      },
+      {
+        "code": "VE-U",
+        "name": "Yaracuy"
+      },
+      {
+        "code": "VE-V",
+        "name": "Zulia"
+      },
+      {
+        "code": "VE-W",
+        "name": "Federal Dependencies"
+      },
+      {
+        "code": "VE-X",
+        "name": "La Guaira (Vargas)"
+      },
+      {
+        "code": "VE-Y",
+        "name": "Delta Amacuro"
+      },
+      {
+        "code": "VE-Z",
+        "name": "Amazonas"
+      }
+    ]
+  },
+  {
+    "code": "VN",
+    "name": "Vietnam",
+    "states": []
+  },
+  {
+    "code": "VG",
+    "name": "Virgin Islands (British)",
+    "states": []
+  },
+  {
+    "code": "VI",
+    "name": "Virgin Islands (US)",
+    "states": []
+  },
+  {
+    "code": "WF",
+    "name": "Wallis and Futuna",
+    "states": []
+  },
+  {
+    "code": "EH",
+    "name": "Western Sahara",
+    "states": []
+  },
+  {
+    "code": "YE",
+    "name": "Yemen",
+    "states": []
+  },
+  {
+    "code": "ZM",
+    "name": "Zambia",
+    "states": [
+      {
+        "code": "ZM-01",
+        "name": "Western"
+      },
+      {
+        "code": "ZM-02",
+        "name": "Central"
+      },
+      {
+        "code": "ZM-03",
+        "name": "Eastern"
+      },
+      {
+        "code": "ZM-04",
+        "name": "Luapula"
+      },
+      {
+        "code": "ZM-05",
+        "name": "Northern"
+      },
+      {
+        "code": "ZM-06",
+        "name": "North-Western"
+      },
+      {
+        "code": "ZM-07",
+        "name": "Southern"
+      },
+      {
+        "code": "ZM-08",
+        "name": "Copperbelt"
+      },
+      {
+        "code": "ZM-09",
+        "name": "Lusaka"
+      },
+      {
+        "code": "ZM-10",
+        "name": "Muchinga"
+      }
+    ]
+  },
+  {
+    "code": "ZW",
+    "name": "Zimbabwe",
+    "states": []
+  }
+]


### PR DESCRIPTION
closes #49 

# Why

In a previous PR #45 we disabled country/state name lookup because the library we were using was not totally compatible with RN.

This PR adds a `country-state.json` file, taken from `wc/v3/data/countries` which contains all the countries & states a user can pick for a shipping zone location.

# Screenshots

<img width="436" alt="Screenshot 2023-06-29 at 4 43 32 PM" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/ce03223a-93f7-4de6-abcd-2d028e6882db">
