### PR TITLE
Add iOS AppPassword Interfaces

### DIFF
--- a/API/RestAPI.tsx
+++ b/API/RestAPI.tsx
@@ -13,6 +13,7 @@ export async function restFetch(
   console.log(`-- About to fetch: ${url}`); // We can delete this but seems handy for the time being to seee what requests are being fired.
 
   return fetch(url, {
+    credentials: "omit", // Do not send any credential cookies left by the apps on the browser.
     headers: {
       Authorization: `Basic ${appPassword}`,
     },

--- a/libraries/ios/WooCommerceShared/WCReactNativeViewController.h
+++ b/libraries/ios/WooCommerceShared/WCReactNativeViewController.h
@@ -9,10 +9,19 @@ NS_ASSUME_NONNULL_BEGIN
                                   blogID:(NSString *)blogId
                                 apiToken: (NSString*) apiToken;
 
+-(instancetype)initWithAnalyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
+                                 siteUrl:(NSString *)siteUrl
+                             appPassword: (NSString*) appPassword;
+
 -(instancetype)initWithBundle:(NSURL *) url
             analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
                        blogID:(NSString *)blogId
                      apiToken: (NSString*) apiToken;
+
+-(instancetype)initWithBundle:(NSURL *) url
+            analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
+                      siteUrl:(NSString *)siteUrl
+                  appPassword: (NSString*) appPassword;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libraries/ios/WooCommerceShared/WCReactNativeViewController.m
+++ b/libraries/ios/WooCommerceShared/WCReactNativeViewController.m
@@ -8,6 +8,8 @@
 @property(atomic, strong) NSURL* bundleUrl;
 @property(atomic, strong) NSString* blogId;
 @property(atomic, strong) NSString* apiToken;
+@property(atomic, strong) NSString* siteUrl;
+@property(atomic, strong) NSString* appPassword;
 @property(atomic, strong) id<WCRNAnalyticsProvider> analyticsProvider;
 @end
 
@@ -47,7 +49,17 @@
         self.apiToken = apiToken;
     }
     return self;
+}
 
+-(instancetype)initWithAnalyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
+                                 siteUrl:(NSString *)siteUrl
+                             appPassword: (NSString*) appPassword {
+    if (self = [self init]) {
+        self.analyticsProvider = analyticsProvider;
+        self.siteUrl = siteUrl;
+        self.appPassword = appPassword;
+    }
+    return self;
 }
 
 -(instancetype)initWithBundle:(NSURL *) url
@@ -63,8 +75,24 @@
     return self;
 }
 
+-(instancetype)initWithBundle:(NSURL *) url
+            analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
+                      siteUrl:(NSString *)siteUrl
+                  appPassword: (NSString*) appPassword {
+    if (self = [super init]) {
+        self.bundleUrl = url;
+        self.analyticsProvider = analyticsProvider;
+        self.siteUrl = siteUrl;
+        self.appPassword = appPassword;
+    }
+    return self;
+}
+
 - (void) loadView {
-    NSDictionary * initialProps = @{@"blogId": self.blogId, @"token": self.apiToken};
+    NSDictionary * initialProps = @{@"blogId": self.blogId ?: [NSNull null],
+                                    @"token": self.apiToken ?: [NSNull null],
+                                    @"siteUrl": self.siteUrl ?: [NSNull null],
+                                    @"appPassword": self.appPassword ?: [NSNull null]};
     WCRNBridge * delegate = [[WCRNBridge alloc] initWithBundleURL:self.bundleUrl analyticsProvider:self.analyticsProvider];
     RCTBridge * bridge = [[RCTBridge alloc] initWithDelegate:delegate launchOptions:[NSDictionary new]];
     self.view = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:initialProps];


### PR DESCRIPTION
# Why

Now that the iOS native-tracks interface has been merged, this PR updates that interface to allow the consumer app to properly pass the app password parameter.

# Discussion

I spend some time dealing with some authentication problems due to the fact that the iOS app leaves some cookies on the session when creating an app password.

When this cookies are sent the `restFetch` does not authenticate correctly. 

The fix is to tell RN to not send any credential cookie with a rest request.

@wzieba could you please check that this does not break android? 🙏 

# Demo

https://github.com/woocommerce/WooCommerce-Shared/assets/562080/c7e30064-0af7-4320-b44b-37a0e43b6f1c


# Testing Steps

As distributing and integrating the rn framework is still under development, you can 
- Trust the video 😛 
or
- Run the WCiOS `feature/rn-integration` and tap on the "Help & Support" button