### PR TITLE
Hide Features Under Development

### DIFF
--- a/ShippingZones.tsx
+++ b/ShippingZones.tsx
@@ -12,12 +12,12 @@ import { fetchShippingZones, ShippingZone } from "./API/ShippingZoneAPI";
 import { useNavigation } from "@react-navigation/native";
 import { NavigationRoutes } from "./Navigation/NavigationRoutes";
 import ToolbarActionButton from "./ToolbarActionButton";
-import { NativeModules } from 'react-native';
+import { NativeModules } from "react-native";
+import { LocalFeatureFlag, isFeatureEnabled } from "./Storage/FeatureFlag";
 
 const sendAnalyticsEvent = (event) => {
   NativeModules.AnalyticsModule.sendEvent(event);
 };
-
 
 type RowProps = {
   title: string;
@@ -38,7 +38,9 @@ function Row(props: RowProps): JSX.Element {
             <Text style={styles.row.caption}> {props.caption} </Text>
           )}
         </View>
-        <Text style={styles.row.disclosureIndicator}>›</Text>
+        {isFeatureEnabled(LocalFeatureFlag.addShippingZones) && (
+          <Text style={styles.row.disclosureIndicator}>›</Text>
+        )}
       </View>
       <View style={styles.row.separator} />
     </View>
@@ -76,7 +78,7 @@ const ShippingZonesList = () => {
     try {
       const zones = await fetchShippingZones();
       setData(zones);
-      sendAnalyticsEvent('shipping_zones_shown');
+      sendAnalyticsEvent("shipping_zones_shown");
     } catch (error) {
       console.log(error);
       showRetryAlert();
@@ -92,6 +94,10 @@ const ShippingZonesList = () => {
   const navigation = useNavigation();
 
   useEffect(() => {
+    if (!isFeatureEnabled(LocalFeatureFlag.addShippingZones)) {
+      return;
+    }
+
     navigation.setOptions({
       headerRight: () => (
         <ToolbarActionButton

--- a/ShippingZones.tsx
+++ b/ShippingZones.tsx
@@ -13,7 +13,7 @@ import { useNavigation } from "@react-navigation/native";
 import { NavigationRoutes } from "./Navigation/NavigationRoutes";
 import ToolbarActionButton from "./ToolbarActionButton";
 import { NativeModules } from "react-native";
-import { LocalFeatureFlag, isFeatureEnabled } from "./Storage/FeatureFlag";
+import { LocalFeatureFlag, isFeatureEnabled } from "./Utils/FeatureFlag";
 
 const sendAnalyticsEvent = (event) => {
   NativeModules.AnalyticsModule.sendEvent(event);

--- a/Storage/FeatureFlag.tsx
+++ b/Storage/FeatureFlag.tsx
@@ -10,7 +10,7 @@ export enum LocalFeatureFlag {
 export function isFeatureEnabled(feature: LocalFeatureFlag) {
   switch (feature) {
     case LocalFeatureFlag.addShippingZones:
-      return false;
+      return __DEV__ === true;
     default:
       throw new Error(`No value for feature: ${feature}`);
   }

--- a/Storage/FeatureFlag.tsx
+++ b/Storage/FeatureFlag.tsx
@@ -1,0 +1,17 @@
+/*
+ * Local feature flag definition.
+ * Useful to hide development code from the production one.
+ */
+
+export enum LocalFeatureFlag {
+  addShippingZones,
+}
+
+export function isFeatureEnabled(feature: LocalFeatureFlag) {
+  switch (feature) {
+    case LocalFeatureFlag.addShippingZones:
+      return false;
+    default:
+      throw new Error(`No value for feature: ${feature}`);
+  }
+}

--- a/Utils/FeatureFlag.tsx
+++ b/Utils/FeatureFlag.tsx
@@ -1,6 +1,7 @@
 /*
  * Local feature flag definition.
  * Useful to hide development code from the production one.
+ * __DEV__ is true when running against the metro server.
  */
 
 export enum LocalFeatureFlag {


### PR DESCRIPTION
Closes #52 

# Why 

This PR adds a simple `isFeatureEnabled` function to allow us to hide development features, like adding shipping zones from a release build.

# Screenshots

Disabled | Enabled
---- | ----
<img width="435" alt="framework" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/4a32ed90-f87a-4c46-afec-d2241988090d"> | <img width="436" alt="metro-server" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/7914cd05-1e38-476e-ac7a-a3589d31db45">
