### PR TITLE
Add Environment values support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ npm-debug.*
 *.orig.*
 web-build/
 yarn-error.log
+.env*
 
 # iOS
 xcuserdata/

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ To work on this project, you'll need a JS runtime. The current JS version is in 
 
 ### Credentials
 
-The demo app read user credentials from the environment.
+The demo app reads user credentials from the environment.
 
-- Create an `.env` in the root folder.
+- Create an `.env` file in the root folder.
 - Set (BLOG_ID and TOKEN) values for WPCom/Jetpack stores or (SITE_URL and APP_PASSWORD) for non WPCom/Jetpack values.
 
 **Example:**

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ A React Native project used to share code between WooCommerce iOS and Android.
 ### iOS – CocoaPods
 
 #### Production Builds
+
 ```ruby
 pod 'woocommerce-shared', '~> 0.0.1'
 ```
 
 #### Development Builds
+
 ```ruby
 # Reference a commit hash
 pod 'WooCommerceShared', git: 'https://github.com/woocommerce/WooCommerce-Shared.git', commit: '6cba1e9'
@@ -26,6 +28,7 @@ pod 'WooCommerceShared', path: '../WooCommerce-Shared'
 ### iOS – SwiftPM
 
 #### Production Builds
+
 ```swift
 dependencies: [
     .package(url: "https://github.com/woocommerce/woocommerce-shared.git", .upToNextMajor(from: "0.0.1"))
@@ -33,6 +36,7 @@ dependencies: [
 ```
 
 #### Development Builds
+
 ```swift
 // Development Builds require two entries – one for the binary target:
 targets: [
@@ -43,14 +47,13 @@ targets: [
     )
 
 ]
- 
+
 // And a second to make the target depend on it:
 .executable(name: "MyApp", targets: [
 	"WooCommerceShared",
 ])
 
 ```
-
 
 ## Development
 
@@ -59,6 +62,29 @@ This project uses `make` for most of its operations. You probably already have i
 ### Prerequisites
 
 To work on this project, you'll need a JS runtime. The current JS version is in the repo's `.nvmrc` file, so if you have `nvm` installed, it'l just work. Otherwise, you'll need that version of `node` installed. If you're doing iOS development, you'll need Ruby installed – we recommend using `rbenv`, which will ensure that you're running the correct version of the tooling. Lastly, this project uses `yarn` as its package manager, so once you have `node` installed, you'll need to run `npm install -g yarn` to ensure the package manager is available everywhere.
+
+### Credentials
+
+The demo app read user credentials from the environment.
+
+- Create an `.env` in the root folder.
+- Set (BLOG_ID and TOKEN) values for WPCom/Jetpack stores or (SITE_URL and APP_PASSWORD) for non WPCom/Jetpack values.
+
+**Example:**
+
+```
+BLOG_ID=12345678
+TOKEN='GH7J8K9WV#CF6798764DF5GHJK987'
+```
+
+or
+
+```
+SITE_URL='https://something.wordpress.com'
+APP_PASSWORD='DERFTGYHUJIKOIJUHYGTFR$%=='
+```
+
+**Note:** When adding or modifying a value we need to restart the metro server in order for changes to be picked up.
 
 ### Setup
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,7 @@
-module.exports = {
-  presets: ["module:metro-react-native-babel-preset"],
+module.exports = function (api) {
+  api.cache(false);
+  return {
+    presets: ["module:metro-react-native-babel-preset"],
+    plugins: ["module:react-native-dotenv"],
+  };
 };

--- a/index.tsx
+++ b/index.tsx
@@ -12,6 +12,8 @@ import {
   setSiteUrl,
 } from "./Storage/InMemoryDependencies";
 
+import { BLOG_ID, TOKEN, APP_PASSWORD, SITE_URL } from "@env";
+
 const Stack = createNativeStackNavigator();
 
 const NavigationStack = (props) => {
@@ -27,10 +29,10 @@ const NavigationStack = (props) => {
   const storeDependencies = () => {
     setSavingDependencies(true);
 
-    setBlogId(props["blogId"]);
-    setApiToken(props["token"]);
-    setSiteUrl(props["siteUrl"]);
-    setAppPassword(props["appPassword"]);
+    setBlogId(props["blogId"] ?? BLOG_ID);
+    setApiToken(props["token"] ?? TOKEN);
+    setSiteUrl(props["siteUrl"] ?? SITE_URL);
+    setAppPassword(props["appPassword"] ?? APP_PASSWORD);
 
     setSavingDependencies(false);
   };

--- a/libraries/ios/Demo App/WCReactNativeViewController+MetroServer.swift
+++ b/libraries/ios/Demo App/WCReactNativeViewController+MetroServer.swift
@@ -38,9 +38,7 @@ extension WCReactNativeViewController {
     ///
     static func forLocalDevelopment(onPort port: UInt16 = 8081) -> WCReactNativeViewController {
         WCReactNativeViewController(bundle: DevServerURL.from(hostname: "localhost", port: port),
-                                    analyticsProvider: FakeAnalyticsProvider(),
-                                    blogID: <#blogid#>,
-                                    apiToken: <#token#>)
+                                    analyticsProvider: FakeAnalyticsProvider())
     }
 
     /// Create a View Controller that allows running an on-device debug build that can connect to the metro server.
@@ -51,9 +49,7 @@ extension WCReactNativeViewController {
         onPort port: UInt16 = 8081
     ) -> WCReactNativeViewController {
         WCReactNativeViewController(bundle: DevServerURL.from(hostname: ipAddress.debugDescription, port: port),
-                                    analyticsProvider: FakeAnalyticsProvider(),
-                                    blogID: <#blogid#>,
-                                    apiToken: <#token#>)
+                                    analyticsProvider: FakeAnalyticsProvider())
     }
 }
 

--- a/libraries/ios/WooCommerceShared/WCReactNativeViewController.h
+++ b/libraries/ios/WooCommerceShared/WCReactNativeViewController.h
@@ -14,14 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
                              appPassword: (NSString*) appPassword;
 
 -(instancetype)initWithBundle:(NSURL *) url
-            analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
-                       blogID:(NSString *)blogId
-                     apiToken: (NSString*) apiToken;
+            analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider;
 
--(instancetype)initWithBundle:(NSURL *) url
-            analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
-                      siteUrl:(NSString *)siteUrl
-                  appPassword: (NSString*) appPassword;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libraries/ios/WooCommerceShared/WCReactNativeViewController.m
+++ b/libraries/ios/WooCommerceShared/WCReactNativeViewController.m
@@ -63,27 +63,10 @@
 }
 
 -(instancetype)initWithBundle:(NSURL *) url
-            analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
-                       blogID:(NSString *)blogId
-                     apiToken: (NSString*) apiToken {
+            analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider {
     if (self = [super init]) {
         self.bundleUrl = url;
         self.analyticsProvider = analyticsProvider;
-        self.blogId =  blogId;
-        self.apiToken = apiToken;
-    }
-    return self;
-}
-
--(instancetype)initWithBundle:(NSURL *) url
-            analyticsProvider:(id<WCRNAnalyticsProvider>) analyticsProvider
-                      siteUrl:(NSString *)siteUrl
-                  appPassword: (NSString*) appPassword {
-    if (self = [super init]) {
-        self.bundleUrl = url;
-        self.analyticsProvider = analyticsProvider;
-        self.siteUrl = siteUrl;
-        self.appPassword = appPassword;
     }
     return self;
 }

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  resetCache: true,
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/jest": "^29.5.3",
     "jest": "^29.6.1",
     "prettier": "2.8.8",
+    "react-native-dotenv": "^3.4.9",
     "ts-jest": "^29.1.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2389,6 +2389,11 @@ diff-sequences@^29.4.3:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.4.3.tgz#9314bc1fabe09267ffeca9cbafc457d8499a13f2"
   integrity sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==
 
+dotenv@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -4799,6 +4804,13 @@ react-native-codegen@^0.71.5:
     flow-parser "^0.185.0"
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
+
+react-native-dotenv@^3.4.9:
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/react-native-dotenv/-/react-native-dotenv-3.4.9.tgz#621c5b0c1d0c5c7f569bfe5a1d804bec7885c010"
+  integrity sha512-dbyd+mcy7SUzxEgmt33TRf1FGcNe6swJhXmB0unKkI49F7+pidog9kPtjxMLTAfmKA8gcN2XHQSKltGfGbGCLQ==
+  dependencies:
+    dotenv "^16.3.1"
 
 react-native-gradle-plugin@^0.71.19:
   version "0.71.19"


### PR DESCRIPTION
Closes #65 

# Why

The demo app needs store credentials to work properly, but in order to not store those credentials in the repo, this PR allows developers to introduce their credentials in an environment file.

# How 

- Create an `.env` file in the root folder.
- Set (BLOG_ID and TOKEN) values for WPCom/Jetpack stores or (SITE_URL and APP_PASSWORD) for non WPCom/Jetpack values.

**Example:**

```
BLOG_ID=12345678
TOKEN='GH7J8K9WV#CF6798764DF5GHJK987'
```

or

```
SITE_URL='https://something.wordpress.com'
APP_PASSWORD='DERFTGYHUJIKOIJUHYGTFR$%=='
```

**Note:** When adding or modifying a value we need to restart the metro server in order for changes to be picked up.

