### PR TITLE
Fix crash when country or state are not found

### DIFF
--- a/Utils/Country.tsx
+++ b/Utils/Country.tsx
@@ -13,7 +13,7 @@ export function getZoneName(countryOrRegion: string) {
   // Handles the {CountryCode} format
   if (zoneComponents.length == 1) {
     const country = getCountryByCode(zoneComponents[0]);
-    if (country == null){
+    if (country == null) {
       return countryOrRegion;
     } else {
       return country.name;
@@ -24,7 +24,11 @@ export function getZoneName(countryOrRegion: string) {
   if (zoneComponents.length == 2) {
     const country = getCountryByCode(zoneComponents[0]);
     const state = getStateByCode(country, zoneComponents[1]);
-    return state.name ?? countryOrRegion;
+    if (state == null) {
+      return countryOrRegion;
+    } else {
+      return state.name;
+    }
   }
 
   return countryOrRegion;

--- a/Utils/Country.tsx
+++ b/Utils/Country.tsx
@@ -13,7 +13,11 @@ export function getZoneName(countryOrRegion: string) {
   // Handles the {CountryCode} format
   if (zoneComponents.length == 1) {
     const country = getCountryByCode(zoneComponents[0]);
-    return country.name ?? countryOrRegion;
+    if (country == null){
+      return countryOrRegion;
+    } else {
+      return country.name;
+    }
   }
 
   // Handles de {CountryCode:StateCode} format

--- a/Utils/_tests/Country.test.tsx
+++ b/Utils/_tests/Country.test.tsx
@@ -15,4 +15,9 @@ describe("Country", () => {
     const zoneName = getZoneName("foobartest")
     expect(zoneName).toBe("foobartest");
   });
+
+  it("returns raw country/region if state is not found in countries list", () => {
+    const zoneName = getZoneName("GB:foobar")
+    expect(zoneName).toBe("GB:foobar");
+  });
 });

--- a/Utils/_tests/Country.test.tsx
+++ b/Utils/_tests/Country.test.tsx
@@ -10,4 +10,9 @@ describe("Country", () => {
     const zoneName = getZoneName("US:NY");
     expect(zoneName).toBe("New York");
   });
+
+  it("returns raw country/region if country is not found in local list", () => {
+    const zoneName = getZoneName("foobartest")
+    expect(zoneName).toBe("foobartest");
+  });
 });


### PR DESCRIPTION
### Description

When the country, or state of the found country, are not found, we've been experiencing NPE. 

From the debugger:
<img width="598" alt="Screenshot 2023-07-26 at 13 55 52" src="https://github.com/woocommerce/WooCommerce-Shared/assets/5845095/e4182445-b763-4de1-b2a8-9b5c0ed08ee6">

when country was `undefined`, getting its `name` was throwing error.

This PR addresses this issue and a similar issue when state of the valid country is not found. See added test cases.
