### PR TITLE
feat: filter out locations not covered by other zones

### DIFF
--- a/API/ShippingZoneAPI.tsx
+++ b/API/ShippingZoneAPI.tsx
@@ -38,20 +38,25 @@ export async function fetchShippingZones() {
     const path = "shipping/zones";
     const response = await apiFetch(WPComAPIVersion.wcV3, path);
     const json = await response.json();
+    const locationsNotCoveredId = 0
 
     if (!response.ok) {
       throw new APIError(path, response.status, json);
     }
 
     const zones: ShippingZone[] = await Promise.all(
-      normalizeJSON(json).map(async (obj) => {
-        return {
-          id: obj.id,
-          title: obj.name,
-          locations: await fetchShippingZoneLocations(obj.id),
-          methods: await fetchShippingZoneMethods(obj.id),
-        };
-      })
+      normalizeJSON(json)
+        .filter((obj) => {
+          return obj.id != locationsNotCoveredId;
+        })
+        .map(async (obj) => {
+          return {
+            id: obj.id,
+            title: obj.name,
+            locations: await fetchShippingZoneLocations(obj.id),
+            methods: await fetchShippingZoneMethods(obj.id),
+          };
+        })
     );
 
     return zones;


### PR DESCRIPTION
Closes: #71 

This PR removes "locations not covered by your other zones" zone from the list. This behaviour is in sync with core.

### Screens

| Before | After |
| --- | --- |
| <img width="566" alt="image" src="https://github.com/woocommerce/WooCommerce-Shared/assets/5845095/0cff69c3-8483-42d2-9a9b-e698ab58bf8f"> | <img width="566" alt="image" src="https://github.com/woocommerce/WooCommerce-Shared/assets/5845095/05b6c589-6456-4026-b8d2-2fed2e10d120"> |

### How do I know "0" is the id of "Locations not covered by your other zones" ?

From core, two sources:
- Static id of this <a href : https://github.com/woocommerce/woocommerce/blob/77af817444f8e2066122cf0d116fb29121af3e61/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zones.php#L26
- When trying to edit zone with id "0", then error message mentions "Locations not covered (...)" https://github.com/woocommerce/woocommerce/blob/77af817444f8e2066122cf0d116fb29121af3e61/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-shipping-zones-v2-controller.php#L171-L173