### PR TITLE
Add Dark Mode Support - Part 1

### DIFF
--- a/ShippingZones.tsx
+++ b/ShippingZones.tsx
@@ -16,6 +16,7 @@ import ToolbarActionButton from "./ToolbarActionButton";
 import { NativeModules } from "react-native";
 import { HeaderBackButton } from "@react-navigation/elements";
 import { LocalFeatureFlag, isFeatureEnabled } from "./Utils/FeatureFlag";
+import { SemanticColor } from "./Utils/SemanticColors";
 
 const sendAnalyticsEvent = (event) => {
   NativeModules.AnalyticsModule.sendEvent(event);
@@ -99,7 +100,11 @@ const ShippingZonesList = () => {
     let options: any = {
       headerLeft: () => (
         <HeaderBackButton
-          tintColor={Platform.OS === "ios" ? "rgb(103, 67, 153)" : undefined}
+          tintColor={
+            Platform.OS === "ios"
+              ? SemanticColor.primary().toString()
+              : undefined
+          }
           style={{ marginLeft: Platform.OS === "ios" ? -15 : -5 }}
           label="Settings"
           labelVisible={false}
@@ -150,22 +155,23 @@ const ShippingZonesList = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: SemanticColor.primaryBackground(),
   },
   list: {
-    backgroundColor: "white",
+    backgroundColor: SemanticColor.primaryBackground(),
     loadingIndicator: {
       marginTop: 32,
     },
   },
   row: {
     flex: 1,
+    backgroundColor: SemanticColor.secondaryBackground(),
     content: {
       flexDirection: "row",
       alignItems: "center",
       padding: 0,
       fontSize: 23,
       borderRadius: 0,
-      backgroundColor: "white",
       margin: 16,
     },
     textContainer: {
@@ -175,25 +181,25 @@ const styles = StyleSheet.create({
       fontFamily: "System",
       fontSize: 17,
       marginBottom: 6,
-      color: "rgb(0, 0, 0)",
+      color: SemanticColor.primaryText(),
     },
     body: {
       fontFamily: "System",
       fontSize: 15,
       marginBottom: 6,
-      color: "rgba(0, 0, 0, 0.6)",
+      color: SemanticColor.secondaryText(),
     },
     caption: {
       fontFamily: "System",
       fontSize: 15,
-      color: "rgba(0, 0, 0, 0.6)",
+      color: SemanticColor.secondaryText(),
     },
     disclosureIndicator: {
       fontSize: 32,
-      color: "rgb(103, 67, 153)",
+      color: SemanticColor.primary(),
     },
     separator: {
-      backgroundColor: "rgba(60, 60, 67, 0.29)",
+      backgroundColor: SemanticColor.separator(),
       height: 0.5,
       marginLeft: 16,
     },

--- a/ShippingZones.tsx
+++ b/ShippingZones.tsx
@@ -100,11 +100,7 @@ const ShippingZonesList = () => {
     let options: any = {
       headerLeft: () => (
         <HeaderBackButton
-          tintColor={
-            Platform.OS === "ios"
-              ? SemanticColor.primary().toString()
-              : undefined
-          }
+          tintColor={SemanticColor.backButton().toString()}
           style={{ marginLeft: Platform.OS === "ios" ? -15 : -5 }}
           label="Settings"
           labelVisible={false}

--- a/ShippingZones.tsx
+++ b/ShippingZones.tsx
@@ -16,7 +16,7 @@ import ToolbarActionButton from "./ToolbarActionButton";
 import { NativeModules } from "react-native";
 import { HeaderBackButton } from "@react-navigation/elements";
 import { LocalFeatureFlag, isFeatureEnabled } from "./Utils/FeatureFlag";
-import { SemanticColor } from "./Utils/SemanticColors";
+import { SemanticColor } from "./Utils/Colors/SemanticColors";
 
 const sendAnalyticsEvent = (event) => {
   NativeModules.AnalyticsModule.sendEvent(event);

--- a/ToolbarActionButton.tsx
+++ b/ToolbarActionButton.tsx
@@ -1,11 +1,13 @@
 import { Platform, Pressable, StyleSheet, Text } from "react-native";
 import React from "react";
+import { SemanticColor } from "./Utils/SemanticColors";
 
 export const ToolbarActionButton = ({
   label,
   onPress,
 }: ToolbarActionButtonProps) => {
-  const formattedLabel = Platform.OS === "android" ? label.toUpperCase() : label;
+  const formattedLabel =
+    Platform.OS === "android" ? label.toUpperCase() : label;
 
   return (
     <Pressable android_ripple={{ borderless: true }} onPress={onPress}>
@@ -15,7 +17,7 @@ export const ToolbarActionButton = ({
 };
 const styles = StyleSheet.create({
   textStyle: {
-    color: "#896bb8",
+    color: SemanticColor.primary(),
     fontSize: 16,
     fontWeight: "600",
   },

--- a/ToolbarActionButton.tsx
+++ b/ToolbarActionButton.tsx
@@ -1,6 +1,6 @@
 import { Platform, Pressable, StyleSheet, Text } from "react-native";
 import React from "react";
-import { SemanticColor } from "./Utils/SemanticColors";
+import { SemanticColor } from "./Utils/Colors/SemanticColors";
 
 export const ToolbarActionButton = ({
   label,

--- a/Utils/Colors/SemanticColors.tsx
+++ b/Utils/Colors/SemanticColors.tsx
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import { Appearance, ColorValue } from "react-native";
 
 export namespace SemanticColor {

--- a/Utils/Colors/SemanticColors.tsx
+++ b/Utils/Colors/SemanticColors.tsx
@@ -1,5 +1,4 @@
-import { useContext } from "react";
-import { Appearance, ColorValue } from "react-native";
+import { Appearance, ColorValue, Platform } from "react-native";
 
 export namespace SemanticColor {
   export const primaryBackground = (): ColorValue => {
@@ -24,6 +23,14 @@ export namespace SemanticColor {
 
   export const separator = (): ColorValue => {
     return isInLightMode() ? "rgba(60, 60, 67, 0.29)" : "rgba(84, 84, 88, 0.6)";
+  };
+
+  export const backButton = (): ColorValue => {
+    if (Platform.OS === "ios") {
+      return primary();
+    } else {
+      return primaryText();
+    }
   };
 
   function isInDarkMode(): boolean {

--- a/Utils/SemanticColors.tsx
+++ b/Utils/SemanticColors.tsx
@@ -1,0 +1,37 @@
+import { Appearance, ColorValue } from "react-native";
+
+export namespace SemanticColor {
+  export const primaryBackground = (): ColorValue => {
+    return isInLightMode() ? "white" : "black";
+  };
+
+  export const secondaryBackground = (): ColorValue => {
+    return isInLightMode() ? "white" : "rgb(28, 28, 30)";
+  };
+
+  export const primaryText = (): ColorValue => {
+    return isInLightMode() ? "black" : "white";
+  };
+
+  export const secondaryText = (): ColorValue => {
+    return isInLightMode() ? "rgba(0, 0, 0, 0.6)" : "gray";
+  };
+
+  export const primary = (): ColorValue => {
+    return isInLightMode() ? "rgb(124, 57, 130)" : "rgb(196, 117, 189)";
+  };
+
+  export const separator = (): ColorValue => {
+    return isInLightMode() ? "rgba(60, 60, 67, 0.29)" : "rgba(84, 84, 88, 0.6)";
+  };
+
+  function isInDarkMode(): boolean {
+    const colorScheme = Appearance.getColorScheme();
+    return colorScheme === "dark";
+  }
+
+  function isInLightMode(): boolean {
+    const colorScheme = Appearance.getColorScheme();
+    return !isInDarkMode();
+  }
+}

--- a/index.tsx
+++ b/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "./Storage/InMemoryDependencies";
 
 import { BLOG_ID, TOKEN, APP_PASSWORD, SITE_URL } from "@env";
+import { SemanticColor } from "./Utils/SemanticColors";
 
 const Stack = createNativeStackNavigator();
 
@@ -58,6 +59,14 @@ const NavigationStack = (props) => {
         <Stack.Navigator
           screenOptions={{
             animation: "slide_from_right",
+            headerStyle: {
+              backgroundColor: SemanticColor.secondaryBackground(),
+            },
+            headerTintColor: SemanticColor.primary(),
+            headerTitleStyle: {
+              color: SemanticColor.primaryText(),
+            },
+            headerBackTitleVisible: false,
           }}
         >
           <Stack.Screen

--- a/index.tsx
+++ b/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { AppRegistry } from "react-native";
+import { AppRegistry, Appearance } from "react-native";
 import ShippingZonesList from "./ShippingZones";
 import AddShippingZone from "./AddShippingZone";
 import { NavigationContainer } from "@react-navigation/native";
@@ -13,7 +13,7 @@ import {
 } from "./Storage/InMemoryDependencies";
 
 import { BLOG_ID, TOKEN, APP_PASSWORD, SITE_URL } from "@env";
-import { SemanticColor } from "./Utils/SemanticColors";
+import { SemanticColor } from "./Utils/Colors/SemanticColors";
 
 const Stack = createNativeStackNavigator();
 


### PR DESCRIPTION
part of #74 

# Why

This PR adds "partial" dark mode support to the library.

Partially: Because it can't handle yet changes from light->dark or dark->light at runtime. The dynamic change support will come in a later PR.

# Screenshots

iOS Light | iOS Dark
--- | ---
<img width="423" alt="light-ios" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/7923143a-2de9-4d67-970e-8de7edd1a581"> | <img width="435" alt="dark-ios" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/fff2ffc1-7f79-41bf-a06f-7bf48088b789">


Android Light | Android Dark
--- | ---
<img width="342" alt="android-light" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/86c99983-9bba-4628-9564-133ee5cdec08"> | <img width="344" alt="android-dark" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/7fd12ea6-f925-4286-b48c-30bd61a6c641">


# Testing Steps

- Start the demo app with a light theme to test light colors
- Start the demo app with a dark theme to test dark colors


@wzieba could you please check if these colors make sense for Android? PS I have not updated the "Add Shipping Method" yet.