### PR TITLE
Do not perform type coercion when comparing id of zones

### DIFF
--- a/API/ShippingZoneAPI.tsx
+++ b/API/ShippingZoneAPI.tsx
@@ -47,7 +47,7 @@ export async function fetchShippingZones() {
     const zones: ShippingZone[] = await Promise.all(
       normalizeJSON(json)
         .filter((obj) => {
-          return obj.id != locationsNotCoveredId;
+          return obj.id !== locationsNotCoveredId;
         })
         .map(async (obj) => {
           return {


### PR DESCRIPTION
It's strange. I've edited the file directly on GitHub in PR view, but GitHub didn't include the commit into the PR, although the commit *was* put on the `issue/71-hide-locations-not-covered` branch 🤔 

<img width="1247" alt="image" src="https://github.com/woocommerce/WooCommerce-Shared/assets/5845095/6ee5a8b5-3957-4926-b9cd-e9f6d8529333">
