### PR TITLE
Remove the filter for publish Android artifacts Buildkite job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,7 +54,6 @@ steps:
             - "AWS_SECRET_KEY"
     agents:
       queue: "android"
-    if: "build.tag != null || build.pull_request.id != null || build.branch == 'trunk'"
 
   #################
   # Lint


### PR DESCRIPTION
We shipped a change to the Buildkite pipeline that applies the filter in this diff at the project level, so we don't need a step level conditional anymore.