### PR TITLE
fix: handle hardware back button in React Native

### DIFF
--- a/AddShippingZone.tsx
+++ b/AddShippingZone.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import {
+  BackHandler,
   Linking,
   Pressable,
   SafeAreaView,
@@ -25,7 +26,19 @@ const AddShippingZone = () => {
           onPress: () => console.log("Toolbar action button pressed"),
         }),
     });
+    BackHandler.addEventListener("hardwareBackPress", handleBackButtonClick);
+    return () => {
+      BackHandler.removeEventListener(
+        "hardwareBackPress",
+        handleBackButtonClick
+      );
+    };
   }, [navigation]);
+
+  function handleBackButtonClick() {
+    navigation.goBack();
+    return true;
+  }
 
   const _renderPostCodes = function () {
     if (isLimitEnabled) {
@@ -62,11 +75,13 @@ const AddShippingZone = () => {
         </View>
       );
     } else {
-      return <Pressable onPress={() => setLimitEnabled(true)}>
-        <Text style={styles.clickableText}>
-          Limit to specific ZIP/postcodes
-        </Text>
-      </Pressable>
+      return (
+        <Pressable onPress={() => setLimitEnabled(true)}>
+          <Text style={styles.clickableText}>
+            Limit to specific ZIP/postcodes
+          </Text>
+        </Pressable>
+      );
     }
   };
 

--- a/libraries/android/library/src/main/kotlin/ReactActivity.kt
+++ b/libraries/android/library/src/main/kotlin/ReactActivity.kt
@@ -85,6 +85,5 @@ class ReactActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
 
     override fun onBackPressed() {
         reactInstanceManager.onBackPressed()
-        super.onBackPressed()
     }
 }


### PR DESCRIPTION
Closes: #84 

## Description
This PR fixes the behaviour of Android back hardware button to expected one (see videos).

### Before
https://github.com/woocommerce/WooCommerce-Shared/assets/5845095/b842ccb3-e446-43b9-983e-078ff5dd6809

### After
https://github.com/woocommerce/WooCommerce-Shared/assets/5845095/6b9106d7-075b-49ef-9a06-b4d3a56fb56f

