### PR TITLE
Show "Locations not covered by..." zones

### DIFF
--- a/API/ShippingZoneAPI.tsx
+++ b/API/ShippingZoneAPI.tsx
@@ -58,25 +58,20 @@ export async function fetchShippingZones(): Promise<ShippingZone[]> {
     const path = "shipping/zones";
     const response = await apiFetch(Method.GET, WPComAPIVersion.wcV3, path);
     const json = await response.json();
-    const locationsNotCoveredId = 0;
 
     if (!response.ok) {
       throw new APIError(path, response.status, json);
     }
 
     const zones: ShippingZone[] = await Promise.all(
-      normalizeJSON(json)
-        .filter((obj) => {
-          return obj.id !== locationsNotCoveredId;
-        })
-        .map(async (obj) => {
-          return {
-            id: obj.id,
-            title: obj.name,
-            locations: await fetchShippingZoneLocations(obj.id),
-            methods: await fetchShippingZoneMethods(obj.id),
-          };
-        })
+      normalizeJSON(json).map(async (obj) => {
+        return {
+          id: obj.id,
+          title: obj.name,
+          locations: await fetchShippingZoneLocations(obj.id),
+          methods: await fetchShippingZoneMethods(obj.id),
+        };
+      })
     );
 
     return zones;

--- a/ShippingZones.tsx
+++ b/ShippingZones.tsx
@@ -78,7 +78,7 @@ const ShippingZonesList = () => {
     try {
       const zones = await fetchShippingZones();
       sendAnalyticsEvent("shipping_zones_list_loaded");
-      setData(zones);
+      setData(decorateZones(zones));
     } catch (error) {
       console.log(error);
       sendAnalyticsEvent("shipping_zones_fetch_failed");
@@ -86,6 +86,23 @@ const ShippingZonesList = () => {
     }
 
     setLoading(false);
+  };
+
+  /*
+   * Updates the given array to move the "Location Not Covered" zone to the bottom of the array.
+   */
+  const decorateZones = (zones: ShippingZone[]) => {
+    const locationsNotCoveredId = 0;
+    const locationsNotCoveredIndex = zones.findIndex(
+      (element) => element.id === locationsNotCoveredId
+    );
+
+    if (locationsNotCoveredIndex >= 0) {
+      let locationNotCoveredZone = zones.splice(locationsNotCoveredIndex, 1)[0];
+      zones.push(locationNotCoveredZone);
+    }
+
+    return zones;
   };
 
   useFocusEffect(


### PR DESCRIPTION
closes #88 

# Why

As per design feedback, this PR stops filtering the "Locations not covered by..." zone and sends it to the end of the list to match web behavior.

# Demo

<img width="438" alt="demo" src="https://github.com/woocommerce/WooCommerce-Shared/assets/562080/be3b1b59-44df-4b6b-b37f-11cef38f2d85">

